### PR TITLE
Improve OpenMP support

### DIFF
--- a/.kateproject
+++ b/.kateproject
@@ -1,0 +1,3 @@
+{
+    "name": "spams-python"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,5 @@
 requires = ["oldest-supported-numpy",
             "setuptools",
             "distro",
-            "wheel"]
+            "wheel",
+            "extension-helpers"]


### PR DESCRIPTION
Instead of manually checking OpenMP availability, it is done thanks to [`extension-helpers`](https://github.com/astropy/extension-helpers) package (c.f. [OpenMP helpers](https://extension-helpers.readthedocs.io/en/latest/openmp.html)).

Interest:
- more clean
- should fix #18 