### PR TITLE
Pin setuptools to <60.0 for numpy.distutils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 requires = ["oldest-supported-numpy",
-            "setuptools",
+            "setuptools<60.0",
             "distro",
             "wheel"]


### PR DESCRIPTION
numpy.distutils is [untested](https://numpy.org/doc/stable/reference/distutils_status_migration.html#numpy-setuptools-interaction) with setuptools>=60.0. Without a version specifier, pip will grab the latest setuptools which may contain breaking changes. https://github.com/pypa/setuptools/pull/3505 released in setuptools 65 broke spams.

numpy.distutils can be ditched once https://github.com/getspams/spams-python/issues/21 is resolved. But to keep spams installable, setuptools needs to be pinned