### PR TITLE
add swig generating files

### DIFF
--- a/tools/R_typemaps.i
+++ b/tools/R_typemaps.i
@@ -1,0 +1,558 @@
+%{
+extern "C" {
+#include <R.h>
+#include <Rinternals.h>
+#include <Rdefines.h>
+#include <R_ext/Rdynload.h>
+#include <Rembedded.h>
+#ifndef WIN32
+#include <Rinterface.h>
+#endif
+#include <R_ext/RS.h>
+#include <R_ext/Error.h>
+}
+#include "spams.h"
+
+/* ********************
+* this is a hack to handle multiple values outrput
+* return value is a vector initailized by swig in typemap out
+* R_result_pos is the index in the vector : it must be set to 0 in typemap(out)
+* typemap(argout) cannot be used without typemap(ou) in a function
+*/
+
+static int R_result_pos = 0;
+
+SEXP appendOutput(SEXP value,SEXP result) {
+     R_result_pos++;
+     if(LENGTH(result) > R_result_pos)
+     	SET_VECTOR_ELT(result,R_result_pos,value);
+     return result;
+}
+/*    end of hack */
+%}
+
+#define myerr(msg,n) {Rf_error(msg,n); return R_NilValue;}
+#define MYADD_OUTPUT_ARG(result, value)  r_ans = appendOutput(value, R_OutputValues);
+
+%typemap(throws) const char * %{
+	Rf_error("Runtime Error %s",$1); 
+	return R_NilValue;
+%}
+
+
+/* One dimensional input arrays */
+%define %vector_typemaps(R_TYPE,R_CAST,DATA_TYPE)
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_POINTER)
+    (Vector<DATA_TYPE> *INPLACE_VECTOR)
+{
+    $1 = (TYPEOF($input) == R_TYPE && Rf_isVector($input) ) ? 1 : 0;
+}
+
+%typemap(in) (Vector<DATA_TYPE> *INPLACE_VECTOR)
+{
+    SEXP rvec=$input;
+    if (TYPEOF(rvec) != R_TYPE || ! Rf_isVector(rvec))
+    {
+        /*SG_ERROR("Expected Double Vector as argument %d\n", m_rhs_counter);*/
+        myerr("Expected DATA_TYPE Vector as argument %d",$argnum);
+    }
+
+    $1 = new Vector<DATA_TYPE>((DATA_TYPE*) R_CAST(rvec), LENGTH(rvec));
+}
+%typemap(out) (Vector<DATA_TYPE> *) 
+{
+    R_result_pos = 0;
+    R_len_t n = result->n();
+    DATA_TYPE *data = result->rawX();
+    SEXP rmat;
+    PROTECT(rmat = Rf_allocMatrix(REALSXP,1,n));
+   if (!rmat) error_return("Cannot alloc R matrix for return value");
+   DATA_TYPE *rdata = (DATA_TYPE *)R_CAST(rmat);
+   memcpy(rdata,data,n * sizeof(DATA_TYPE));
+   delete result;
+   $result = rmat;
+   UNPROTECT(1);
+ 
+}
+%typemap(freearg) (Vector<DATA_TYPE> *INPLACE_VECTOR)
+{
+	delete arg$argnum;
+}
+//  ARGOUT
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY) (Vector<DATA_TYPE> **ARGOUT_VECTOR)
+{
+	$1 = 1;
+
+}
+%typemap(in,numinputs=0) (Vector<DATA_TYPE> **ARGOUT_VECTOR)
+	     (Vector<DATA_TYPE>  *data_temp)
+{
+    $1 = &data_temp;
+}
+%typemap(argout) (Vector<DATA_TYPE> **ARGOUT_VECTOR ) 
+{
+	  # test argout
+	  if(data_temp$argnum != NULL) {
+	    R_len_t n = data_temp$argnum->n();
+	    DATA_TYPE *data = data_temp$argnum->rawX();
+	    SEXP rmat;
+	    PROTECT(rmat = Rf_allocMatrix(R_TYPE,1,n));
+	   if (!rmat) myerr("Cannot alloc R matrix for arg %d",$argnum);
+	   DATA_TYPE *rdata = (DATA_TYPE *)R_CAST(rmat);
+	   memcpy(rdata,data,n * sizeof(DATA_TYPE));
+	   delete data_temp$argnum;
+	   MYADD_OUTPUT_ARG($result,rmat);
+	   UNPROTECT(1);
+        }
+}
+
+%enddef /* %vector_typemaps */
+
+%define map_matrix(DATA_TYPE,R_TYPE,R_CAST)
+     SEXP rmat=$input;
+     SEXP dims = Rf_getAttrib(rmat,Rf_install("dim"));
+    if (TYPEOF(rmat) != R_TYPE || LENGTH(dims) != 2)	
+    {	
+        /*SG_ERROR("Expected Double Vector as argument %d\n", m_rhs_counter);*/
+        myerr("Expected DATA_TYPE dense matrix as argument %d",$argnum);
+    }
+    $1 = new Matrix<DATA_TYPE> ((DATA_TYPE *)R_CAST(rmat),Rf_nrows(rmat),Rf_ncols(rmat));
+
+%enddef /* map_matrix */
+
+/* full matrix input/output */
+%typemap(in) (Matrix<bool> *INPLACE_MATRIX)
+{
+     SEXP rmat=$input;
+     SEXP dims = Rf_getAttrib(rmat,Rf_install("dim"));
+    if (TYPEOF(rmat) != LGLSXP || LENGTH(dims) != 2)	
+    {	
+        /*SG_ERROR("Expected Double Vector as argument %d\n", m_rhs_counter);*/
+        myerr("Expected bool dense matrix as argument %d",$argnum);
+    }
+      	 $1 = new Matrix<bool> (Rf_nrows(rmat),Rf_ncols(rmat));
+	 int *pi = (int *)LOGICAL(rmat);
+	 bool *po = $1->rawX();
+	 for(int i =0;i < Rf_nrows(rmat) * Rf_ncols(rmat);i++)
+	 	*po++ = (bool) *pi++;
+         
+}
+%typemap(freearg)
+  (Matrix<bool> *INPLACE_MATRIX)
+{
+	delete arg$argnum;
+}
+
+%define %matrix_typemaps(R_TYPE,R_CAST,DATA_TYPE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY)
+           (Matrix<DATA_TYPE> *INPLACE_MATRIX)
+{
+	$1 = (TYPEOF($input) == R_TYPE) ? 1 : 0;
+
+}
+%typemap(in) (Matrix<DATA_TYPE> *INPLACE_MATRIX)
+{
+     map_matrix(DATA_TYPE,R_TYPE,R_CAST)
+}
+%typemap(out) (Matrix<DATA_TYPE> *) 
+{
+    R_result_pos = 0;
+    R_len_t m = result->m();
+    R_len_t n = result->n();
+    DATA_TYPE *data = result->rawX();
+    SEXP rmat;
+    PROTECT(rmat = Rf_allocMatrix(REALSXP,m,n));
+   if (!rmat) error_return("Cannot alloc R matrix for return value");
+   DATA_TYPE *rdata = (DATA_TYPE *)R_CAST(rmat);
+   memcpy(rdata,data,m * n * sizeof(DATA_TYPE));
+   delete result;
+   $result = rmat;
+   UNPROTECT(1);
+ 
+}
+
+%typemap(freearg)
+  (Matrix<DATA_TYPE> *INPLACE_MATRIX)
+{
+	delete arg$argnum;
+}
+//  ARGOUT
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY) (Matrix<DATA_TYPE> **ARGOUT_MATRIX)
+{
+	$1 = 1;
+
+}
+%typemap(in,numinputs=0) (Matrix<DATA_TYPE> **ARGOUT_MATRIX)
+	     (Matrix<DATA_TYPE>  *data_temp)
+{
+    $1 = &data_temp;
+}
+%typemap(argout) (Matrix<DATA_TYPE> **ARGOUT_MATRIX ) 
+{
+	  # test argout
+	  if(data_temp$argnum != NULL) {
+	    R_len_t m = data_temp$argnum->m();
+	    R_len_t n = data_temp$argnum->n();
+	    DATA_TYPE *data = data_temp$argnum->rawX();
+	    SEXP rmat;
+	    PROTECT(rmat = Rf_allocMatrix(REALSXP,m,n));
+	   if (!rmat) myerr("Cannot alloc R matrix for arg %d",$argnum);
+	   DATA_TYPE *rdata = (DATA_TYPE *)R_CAST(rmat);
+	   memcpy(rdata,data,m * n * sizeof(DATA_TYPE));
+	   delete data_temp$argnum;
+	   MYADD_OUTPUT_ARG($result,rmat);
+	   UNPROTECT(1);
+        }
+}
+
+%enddef /* %matrix_typemaps */
+
+%fragment("DSp_Check","header")
+{
+    const int check_sparse(SEXP arg) {
+	SEXP ivec = Rf_getAttrib(arg,Rf_install("i"));
+	SEXP xvec = Rf_getAttrib(arg,Rf_install("x"));
+	SEXP dims = Rf_getAttrib(arg,Rf_install("Dim"));
+//	return (Rf_isInteger(ivec) && (TYPEOF(xvec) == R_TYPE) && (LENGTH(dims) == 2) ? 1 : 0);
+	return (Rf_isInteger(ivec) && (TYPEOF(xvec) == REALSXP) && (LENGTH(dims) == 2) ? 1 : 0);
+
+    }
+    const int check_matrix(SEXP arg) {
+    	  SEXP dims = Rf_getAttrib(arg,Rf_install("dim"));
+	  return ((TYPEOF(arg) == REALSXP) && (LENGTH(dims) == 2) ? 1 : 0);
+    }
+}
+%define map_sparse(DATA_TYPE,R_TYPE,R_CAST)
+     SEXP spmat=$input;
+     SEXP ivec = Rf_getAttrib(spmat,Rf_install("i"));
+     SEXP pvec = Rf_getAttrib(spmat,Rf_install("p"));
+     SEXP xvec = Rf_getAttrib(spmat,Rf_install("x"));
+     SEXP dims = Rf_getAttrib(spmat,Rf_install("Dim"));
+
+     if (TYPEOF(xvec) != R_TYPE || LENGTH(dims) != 2)	
+    {	
+        /*SG_ERROR("Expected Double Vector as argument %d\n", m_rhs_counter);*/
+        myerr("Expected DATA_TYPE sparse matrix as argument %d",$argnum);
+    }
+     int *pB = INTEGER(pvec);
+     int *pE = pB + 1;
+     int *idims = INTEGER(dims);
+     $1 = new SpMatrix<DATA_TYPE> ((DATA_TYPE *)R_CAST(xvec),INTEGER(ivec),pB,pE,idims[0],idims[1],LENGTH(xvec));
+	
+%enddef /* map_sparse */
+
+/* special case for type bool (32bits in R , 8 bits in C++) */
+%typemap(in) (SpMatrix<bool> *INPLACE_SPMATRIX)
+{
+     SEXP spmat=$input;
+     SEXP ivec = Rf_getAttrib(spmat,Rf_install("i"));
+     SEXP pvec = Rf_getAttrib(spmat,Rf_install("p"));
+     SEXP xvec = Rf_getAttrib(spmat,Rf_install("x"));
+     SEXP dims = Rf_getAttrib(spmat,Rf_install("Dim"));
+
+     if (TYPEOF(xvec) != LGLSXP || LENGTH(dims) != 2)	
+    {	
+        myerr("Expected bool sparse matrix as argument %d",$argnum);
+    }
+    int nzmax = LENGTH(xvec);
+     $1 = new SpMatrix<bool> (idims[0],idims[1],nzmax);
+     int *pB = INTEGER(pvec);
+     int *pE = pB + 1;
+     int *idims = INTEGER(dims);
+     int *pi = (int *)LOGICAL(xvec);
+     memcpy($1->pB(),INTEGER(ivec),(idims[1] + 1) * sizeof(int));
+     memcpy($1->r(),INTEGER(pvec),nzmax * sizeof(int));
+     bool *po = $1->v();
+     for(int i =0;i < nzmax;i++)
+	*po++ = (bool) *pi++;
+}
+%typemap(freearg)
+  (SpMatrix<bool> *INPLACE_SPMATRIX)
+{
+	delete arg$argnum;
+}
+
+%define %spmatrix_typemaps(R_TYPE,R_CAST,DATA_TYPE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+	fragment="DSp_Check")
+        (SpMatrix<DATA_TYPE> *INPLACE_SPMATRIX)
+{
+	$1 = check_sparse((SEXP) $input);
+
+}
+%typemap(in) (SpMatrix<DATA_TYPE> *INPLACE_SPMATRIX)
+{
+     map_sparse(DATA_TYPE,R_TYPE,R_CAST)
+}
+%typemap(freearg)
+  (SpMatrix<DATA_TYPE> *INPLACE_SPMATRIX)
+{
+	delete arg$argnum;
+}
+
+%typemap(out) (SpMatrix<DATA_TYPE> *) 
+{
+    R_result_pos = 0;
+    R_len_t m = result->m();
+    R_len_t n = result->n();
+    R_len_t nzmax = result->nzmax();
+    SEXP indptr, indices, vdata, dims, output;
+    PROTECT(indptr = Rf_allocVector(INTSXP,n + 1));
+    PROTECT(indices = Rf_allocVector(INTSXP,nzmax));
+    PROTECT(vdata = Rf_allocVector(REALSXP,nzmax));
+    PROTECT(dims = Rf_allocVector(VECSXP,2));
+    SET_VECTOR_ELT(dims,0,Rf_ScalarInteger(m));
+    SET_VECTOR_ELT(dims,1,Rf_ScalarInteger(n));
+
+    DATA_TYPE *xdata = result->v();
+    memcpy(R_CAST(vdata),xdata,nzmax * sizeof(DATA_TYPE));
+    int *pB = result->pB();
+    int *r = result->r();
+    memcpy(INTEGER(indices),r,nzmax * sizeof(int));
+    memcpy(INTEGER(indptr),pB,(n + 1) * sizeof(int));
+    
+    PROTECT(output = Rf_allocVector(VECSXP,4));
+    SET_VECTOR_ELT(output,0,indptr);
+    SET_VECTOR_ELT(output,1,indices);
+    SET_VECTOR_ELT(output,2,vdata);
+    SET_VECTOR_ELT(output,3,dims);
+    delete result;
+    $result = output;
+    UNPROTECT(5);
+}
+
+%typemap(freearg)
+  (SpMatrix<DATA_TYPE> *INPLACE_SPMATRIX)
+{
+	delete arg$argnum;
+}
+// ARGOUT
+%typemap(in,numinputs=0) (SpMatrix<DATA_TYPE> **ARGOUT_SPMATRIX ) 
+(SpMatrix<DATA_TYPE> *data_temp)
+{
+	$1 = &data_temp;
+}
+%typemap(argout) (SpMatrix<DATA_TYPE> **ARGOUT_SPMATRIX ) 
+{
+  if(data_temp$argnum != NULL) {
+    R_len_t m = data_temp$argnum->m();
+    R_len_t n = data_temp$argnum->n();
+    R_len_t nzmax = data_temp$argnum->nzmax();
+    SEXP indptr, indices, vdata, dims, output;
+    PROTECT(indptr = Rf_allocVector(INTSXP,n + 1));
+    PROTECT(indices = Rf_allocVector(INTSXP,nzmax));
+    PROTECT(vdata = Rf_allocVector(R_TYPE,nzmax));
+    PROTECT(dims = Rf_allocVector(VECSXP,2));
+    SET_VECTOR_ELT(dims,0,Rf_ScalarInteger(m));
+    SET_VECTOR_ELT(dims,1,Rf_ScalarInteger(n));
+
+    DATA_TYPE *xdata = data_temp$argnum->v();
+    memcpy(R_CAST(vdata),xdata,nzmax * sizeof(DATA_TYPE));
+    int *pB = data_temp$argnum->pB();
+    int *r = data_temp$argnum->r();
+    memcpy(INTEGER(indices),r,nzmax * sizeof(int));
+    memcpy(INTEGER(indptr),pB,(n + 1) * sizeof(int));
+    delete data_temp$argnum;
+    PROTECT(output = Rf_allocVector(VECSXP,4));
+    SET_VECTOR_ELT(output,0,indptr);
+    SET_VECTOR_ELT(output,1,indices);
+    SET_VECTOR_ELT(output,2,vdata);
+    SET_VECTOR_ELT(output,3,dims);
+    MYADD_OUTPUT_ARG($result,output);
+    UNPROTECT(5);
+  }
+}
+%enddef /* %spmatrix_typemaps */
+
+%define %dspmatrix_typemaps(R_TYPE,R_CAST,DATA_TYPE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+	fragment="DSp_Check")
+        (AbstractMatrixB<DATA_TYPE> *INPLACE_DSPMATRIX)
+{
+	SEXP pvec = Rf_getAttrib($input,Rf_install("p"));
+	if(pvec == R_NilValue) {
+	    $1 = check_matrix((SEXP) $input);
+	 } else {
+	    $1 = check_sparse((SEXP) $input);
+	 }
+
+}
+%typemap(in) (AbstractMatrixB<DATA_TYPE> *INPLACE_DSPMATRIX)
+{
+    SEXP pvec = Rf_getAttrib($input,Rf_install("p"));
+    if(pvec ==  R_NilValue) {
+       map_matrix(DATA_TYPE,R_TYPE,R_CAST)
+    } else {
+       map_sparse(DATA_TYPE,R_TYPE,R_CAST)
+    }
+}
+%typemap(freearg)
+  (AbstractMatrixB<DATA_TYPE> *INPLACE_DSPMATRIX)
+{
+	delete arg$argnum;
+}
+
+%enddef /* %dspmatrix_typemaps */
+
+%define %datamatrix_typemaps(R_TYPE,R_CAST,DATA_TYPE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+	fragment="DSp_Check")
+        (Data<DATA_TYPE> *INPLACE_DATAMATRIX)
+{
+	SEXP pvec = Rf_getAttrib($input,Rf_install("p"));
+	if(pvec == R_NilValue) {
+	    $1 = check_matrix((SEXP) $input);
+	 } else {
+	    $1 = check_sparse((SEXP) $input);
+	 }
+
+}
+%typemap(in) (Data<DATA_TYPE> *INPLACE_DATAMATRIX)
+{
+    SEXP pvec = Rf_getAttrib($input,Rf_install("p"));
+    if(pvec ==  R_NilValue) {
+       map_matrix(DATA_TYPE,R_TYPE,R_CAST)
+    } else {
+       map_sparse(DATA_TYPE,R_TYPE,R_CAST)
+    }
+}
+%typemap(freearg)
+  (Data<DATA_TYPE> *INPLACE_DATAMATRIX)
+{
+	delete arg$argnum;
+}
+
+%enddef /* %datamatrix_typemaps */
+
+%define %node_typemaps(R_TYPE,R_CAST,DATA_TYPE)
+%typemap(out) (std::vector<StructNodeElem<DATA_TYPE> *> *)
+{	      
+  int n = result->size();
+  SEXP node_list;
+  PROTECT(node_list = Rf_allocVector(VECSXP,n));
+  int i = 0;
+  for(std::vector<StructNodeElem<DATA_TYPE> *>::iterator it = result->begin();it != result->end();it++, i++) {
+    SEXP vars, children, elem;
+    PROTECT(elem = Rf_allocVector(VECSXP,4));
+    StructNodeElem<DATA_TYPE> *node = *it;
+    int inode = node->node_num;
+    SET_VECTOR_ELT(elem,0,Rf_ScalarInteger(inode));
+    SET_VECTOR_ELT(elem,1,Rf_ScalarReal(node->weight));
+    int k = node->vars->size();
+    PROTECT(vars = Rf_allocVector(INTSXP,k));
+    int * rvars = (int *)INTEGER(vars);
+    memcpy(rvars,node->vars->data(),k * sizeof(int));
+    SET_VECTOR_ELT(elem,2,vars);
+
+    k = node->children->size();
+    PROTECT(children = Rf_allocVector(INTSXP,k));
+    int * rchildren = (int *)INTEGER(children);
+    memcpy(rchildren,node->children->data(),k * sizeof(int));
+    SET_VECTOR_ELT(elem,3,children);
+    
+    SET_VECTOR_ELT(node_list,i,elem);
+    UNPROTECT(3);
+  }
+  del_gstruct(result);
+  $result = node_list;
+  UNPROTECT(1);
+}
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_POINTER)
+    (std::vector<StructNodeElem<DATA_TYPE> *> *TREE)
+{
+    $1 = (TYPEOF($input) == VECSXP && Rf_isVector($input) ) ? 1 : 0;
+}
+%typemap(in)
+  (std::vector<StructNodeElem<DATA_TYPE> *> *TREE) 
+{
+  SEXP rtree = $input;
+  if(TYPEOF(rtree) != VECSXP || ! Rf_isVector(rtree)) {
+    myerr("Expected VECSXP Vector as argument %d",$argnum);
+  }
+  $1 = new std::vector<StructNodeElem<DATA_TYPE> *>;
+  int n = Rf_length(rtree);
+  for (int i = 0;i < n;i++) {
+    SEXP rnode = VECTOR_ELT(rtree,i);
+    if(TYPEOF(rnode) != VECSXP || ! Rf_isVector(rnode)) {
+      myerr("Bad type for node elem in arg %d",$argnum);
+    }
+    if(Rf_length(rnode) != 4) {
+      myerr("A node must have 4 elements in arg %d",$argnum);
+    }
+    int inode = *((int *) INTEGER(VECTOR_ELT(rnode,0)));
+    double w = *((double *)REAL(VECTOR_ELT(rnode,1)));
+    std::vector<int> *vars = new std::vector<int>;
+    std::vector<int> *children = new std::vector<int>;
+    SEXP rvars = VECTOR_ELT(rnode,2);
+    SEXP rchildren = VECTOR_ELT(rnode,3);
+    int *pvars = (int *) INTEGER(rvars);
+    int *pchildren = (int *) INTEGER(rchildren);
+    for(int i = 0;i < Rf_length(rvars);i++)
+      vars->push_back(*pvars++);
+    for(int i = 0;i < Rf_length(rchildren);i++)
+      children->push_back(*pchildren++);
+    StructNodeElem<DATA_TYPE> *node = new StructNodeElem<DATA_TYPE>(inode,w,vars,children);
+    $1->push_back(node);
+  }
+}
+
+%typemap(freearg)
+  (std::vector<StructNodeElem<DATA_TYPE> *> *TREE)
+{
+  del_gstruct(arg$argnum);
+}
+%enddef /* %node_typemaps */
+
+/* ********************** */
+
+%vector_typemaps(REALSXP,REAL,float)
+%vector_typemaps(REALSXP,REAL,double)
+%vector_typemaps(INTSXP,INTEGER,int)
+
+%matrix_typemaps(REALSXP,REAL,float)
+%matrix_typemaps(REALSXP,REAL,double)
+#%matrix_typemaps(LGLSXP,LOGICAL,bool)
+
+%spmatrix_typemaps(REALSXP,REAL,float)
+%spmatrix_typemaps(REALSXP,REAL,double)
+%spmatrix_typemaps(LGLSXP,LOGICAL,bool)
+
+%dspmatrix_typemaps(REALSXP,REAL,float)
+%dspmatrix_typemaps(REALSXP,REAL,double)
+
+%datamatrix_typemaps(REALSXP,REAL,float)
+%datamatrix_typemaps(REALSXP,REAL,double)
+
+%node_typemaps(REALSXP,REAL,float)
+%node_typemaps(REALSXP,REAL,double)
+
+// must instatiate templates with different names, else generated R file will do bad dispatching
+%define INSTANTIATE_DATA( f_name )
+%template(## f_name) _ ## f_name<double>;
+//%template(f_ ## f_name) _ ## f_name<float>;
+%enddef
+
+
+
+// ARGOUTVIEW_ARRAY1
+%typemap(in,numinputs=0) (int** ARGOUTVIEW_ARRAY1,int* DIM1)
+  (int *data_temp, int dim_temp)
+{
+	$1 = &data_temp;
+	$2 = &dim_temp;
+}
+%typemap(argout) (int** ARGOUTVIEW_ARRAY1,int* DIM1) 
+{
+  SEXP perm;
+  if(data_temp$argnum != NULL) {
+    int n = dim_temp$argnum;
+    PROTECT(perm = Rf_allocVector(INTSXP,n));
+    int *pperm = INTEGER(perm);
+    memcpy(pperm,data_temp$argnum,n * sizeof(int));
+    delete []data_temp$argnum;
+    UNPROTECT(1);
+  } else perm = R_NilValue;
+  MYADD_OUTPUT_ARG($result,perm);
+}

--- a/tools/numpy.i
+++ b/tools/numpy.i
@@ -1,0 +1,2970 @@
+/* -*- C -*-  (not really, but good for syntax highlighting) */
+
+/*
+ * Copyright (c) 2005-2015, NumPy Developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials provided
+ *        with the distribution.
+ *
+ *     * Neither the name of the NumPy Developers nor the names of any
+ *        contributors may be used to endorse or promote products derived
+ *        from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef SWIGPYTHON
+
+%{
+#ifndef SWIG_FILE_WITH_INIT
+#define NO_IMPORT_ARRAY
+#endif
+#include "stdio.h"
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+%}
+
+/**********************************************************************/
+
+%fragment("NumPy_Backward_Compatibility", "header")
+{
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+%#define NPY_ARRAY_DEFAULT NPY_DEFAULT
+%#define NPY_ARRAY_FARRAY  NPY_FARRAY
+%#define NPY_FORTRANORDER  NPY_FORTRAN
+%#endif
+}
+
+/**********************************************************************/
+
+/* The following code originally appeared in
+ * enthought/kiva/agg/src/numeric.i written by Eric Jones.  It was
+ * translated from C++ to C by John Hunter.  Bill Spotz has modified
+ * it to fix some minor bugs, upgrade from Numeric to numpy (all
+ * versions), add some comments and functionality, and convert from
+ * direct code insertion to SWIG fragments.
+ */
+
+%fragment("NumPy_Macros", "header")
+{
+/* Macros to extract array attributes.
+ */
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+%#define is_array(a)            ((a) && PyArray_Check((PyArrayObject*)a))
+%#define array_type(a)          (int)(PyArray_TYPE((PyArrayObject*)a))
+%#define array_numdims(a)       (((PyArrayObject*)a)->nd)
+%#define array_dimensions(a)    (((PyArrayObject*)a)->dimensions)
+%#define array_size(a,i)        (((PyArrayObject*)a)->dimensions[i])
+%#define array_strides(a)       (((PyArrayObject*)a)->strides)
+%#define array_stride(a,i)      (((PyArrayObject*)a)->strides[i])
+%#define array_data(a)          (((PyArrayObject*)a)->data)
+%#define array_descr(a)         (((PyArrayObject*)a)->descr)
+%#define array_flags(a)         (((PyArrayObject*)a)->flags)
+%#define array_clearflags(a,f)  (((PyArrayObject*)a)->flags) &= ~f
+%#define array_enableflags(a,f) (((PyArrayObject*)a)->flags) = f
+%#define array_is_fortran(a)    (PyArray_ISFORTRAN((PyArrayObject*)a))
+%#else
+%#define is_array(a)            ((a) && PyArray_Check(a))
+%#define array_type(a)          PyArray_TYPE((PyArrayObject*)a)
+%#define array_numdims(a)       PyArray_NDIM((PyArrayObject*)a)
+%#define array_dimensions(a)    PyArray_DIMS((PyArrayObject*)a)
+%#define array_strides(a)       PyArray_STRIDES((PyArrayObject*)a)
+%#define array_stride(a,i)      PyArray_STRIDE((PyArrayObject*)a,i)
+%#define array_size(a,i)        PyArray_DIM((PyArrayObject*)a,i)
+%#define array_data(a)          PyArray_DATA((PyArrayObject*)a)
+%#define array_descr(a)         PyArray_DESCR((PyArrayObject*)a)
+%#define array_flags(a)         PyArray_FLAGS((PyArrayObject*)a)
+%#define array_enableflags(a,f) PyArray_ENABLEFLAGS((PyArrayObject*)a,f)
+%#define array_clearflags(a,f)  PyArray_CLEARFLAGS((PyArrayObject*)a,f)
+%#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
+%#endif
+%#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
+%#define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
+}
+
+/**********************************************************************/
+
+%fragment("NumPy_Utilities",
+          "header")
+{
+  /* Given a PyObject, return a string describing its type.
+   */
+  const char* pytype_string(PyObject* py_obj)
+  {
+    if (py_obj == NULL          ) return "C NULL value";
+    if (py_obj == Py_None       ) return "Python None" ;
+    if (PyCallable_Check(py_obj)) return "callable"    ;
+    if (PyBytes_Check(   py_obj)) return "string"      ;
+    if (PyLong_Check(    py_obj)) return "int"         ;
+    if (PyFloat_Check(   py_obj)) return "float"       ;
+    if (PyDict_Check(    py_obj)) return "dict"        ;
+    if (PyList_Check(    py_obj)) return "list"        ;
+    if (PyTuple_Check(   py_obj)) return "tuple"       ;
+
+    return "unknown type";
+  }
+
+  /* Given a NumPy typecode, return a string describing the type.
+   */
+  const char* typecode_string(int typecode)
+  {
+    static const char* type_names[25] = {"bool",
+                                         "byte",
+                                         "unsigned byte",
+                                         "short",
+                                         "unsigned short",
+                                         "int",
+                                         "unsigned int",
+                                         "long",
+                                         "unsigned long",
+                                         "long long",
+                                         "unsigned long long",
+                                         "float",
+                                         "double",
+                                         "long double",
+                                         "complex float",
+                                         "complex double",
+                                         "complex long double",
+                                         "object",
+                                         "string",
+                                         "unicode",
+                                         "void",
+                                         "ntypes",
+                                         "notype",
+                                         "char",
+                                         "unknown"};
+    return typecode < 24 ? type_names[typecode] : type_names[24];
+  }
+
+  /* Make sure input has correct numpy type.  This now just calls
+     PyArray_EquivTypenums().
+   */
+  int type_match(int actual_type,
+                 int desired_type)
+  {
+    return PyArray_EquivTypenums(actual_type, desired_type);
+  }
+
+void free_cap(PyObject * cap)
+  {
+    void* array = (void*) PyCapsule_GetPointer(cap,SWIGPY_CAPSULE_NAME);
+    if (array != NULL) free(array);
+  }
+
+
+}
+
+/**********************************************************************/
+
+%fragment("NumPy_Object_to_Array",
+          "header",
+          fragment="NumPy_Backward_Compatibility",
+          fragment="NumPy_Macros",
+          fragment="NumPy_Utilities")
+{
+  /* Given a PyObject pointer, cast it to a PyArrayObject pointer if
+   * legal.  If not, set the python error string appropriately and
+   * return NULL.
+   */
+  PyArrayObject* obj_to_array_no_conversion(PyObject* input,
+                                            int        typecode)
+  {
+    PyArrayObject* ary = NULL;
+    if (is_array(input) && (typecode == NPY_NOTYPE ||
+                            PyArray_EquivTypenums(array_type(input), typecode)))
+    {
+      ary = (PyArrayObject*) input;
+    }
+    else if is_array(input)
+    {
+      const char* desired_type = typecode_string(typecode);
+      const char* actual_type  = typecode_string(array_type(input));
+      PyErr_Format(PyExc_TypeError,
+                   "Array of type '%s' required.  Array of type '%s' given",
+                   desired_type, actual_type);
+      ary = NULL;
+    }
+    else
+    {
+      const char* desired_type = typecode_string(typecode);
+      const char* actual_type  = pytype_string(input);
+      PyErr_Format(PyExc_TypeError,
+                   "Array of type '%s' required.  A '%s' was given",
+                   desired_type,
+                   actual_type);
+      ary = NULL;
+    }
+    return ary;
+  }
+
+  /* Convert the given PyObject to a NumPy array with the given
+   * typecode.  On success, return a valid PyArrayObject* with the
+   * correct type.  On failure, the python error string will be set and
+   * the routine returns NULL.
+   */
+  PyArrayObject* obj_to_array_allow_conversion(PyObject* input,
+                                               int       typecode,
+                                               int*      is_new_object)
+  {
+    PyArrayObject* ary = NULL;
+    PyObject*      py_obj;
+    if (is_array(input) && (typecode == NPY_NOTYPE ||
+                            PyArray_EquivTypenums(array_type(input),typecode)))
+    {
+      ary = (PyArrayObject*) input;
+      *is_new_object = 0;
+    }
+    else
+    {
+      py_obj = PyArray_FROMANY(input, typecode, 0, 0, NPY_ARRAY_DEFAULT);
+      /* If NULL, PyArray_FromObject will have set python error value.*/
+      ary = (PyArrayObject*) py_obj;
+      *is_new_object = 1;
+    }
+    return ary;
+  }
+
+  /* Given a PyArrayObject, check to see if it is contiguous.  If so,
+   * return the input pointer and flag it as not a new object.  If it is
+   * not contiguous, create a new PyArrayObject using the original data,
+   * flag it as a new object and return the pointer.
+   */
+  PyArrayObject* make_contiguous(PyArrayObject* ary,
+                                 int*           is_new_object,
+                                 int            min_dims,
+                                 int            max_dims)
+  {
+    PyArrayObject* result;
+    if (array_is_contiguous(ary))
+    {
+      result = ary;
+      *is_new_object = 0;
+    }
+    else
+    {
+      result = (PyArrayObject*) PyArray_ContiguousFromObject((PyObject*)ary,
+                                                              array_type(ary),
+                                                              min_dims,
+                                                              max_dims);
+      *is_new_object = 1;
+    }
+    return result;
+  }
+
+  /* Given a PyArrayObject, check to see if it is Fortran-contiguous.
+   * If so, return the input pointer, but do not flag it as not a new
+   * object.  If it is not Fortran-contiguous, create a new
+   * PyArrayObject using the original data, flag it as a new object
+   * and return the pointer.
+   */
+  PyArrayObject* make_fortran(PyArrayObject* ary,
+                              int*           is_new_object)
+  {
+    PyArrayObject* result;
+    if (array_is_fortran(ary))
+    {
+      result = ary;
+      *is_new_object = 0;
+    }
+    else
+    {
+      Py_INCREF(array_descr(ary));
+      result = (PyArrayObject*) PyArray_FromArray(ary,
+                                                  array_descr(ary),
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+                                                  NPY_FORTRANORDER);
+%#else
+                                                  NPY_ARRAY_F_CONTIGUOUS);
+%#endif
+      *is_new_object = 1;
+    }
+    return result;
+  }
+
+  /* Convert a given PyObject to a contiguous PyArrayObject of the
+   * specified type.  If the input object is not a contiguous
+   * PyArrayObject, a new one will be created and the new object flag
+   * will be set.
+   */
+  PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+                                                          int       typecode,
+                                                          int*      is_new_object)
+  {
+    int is_new1 = 0;
+    int is_new2 = 0;
+    PyArrayObject* ary2;
+    PyArrayObject* ary1 = obj_to_array_allow_conversion(input,
+                                                        typecode,
+                                                        &is_new1);
+    if (ary1)
+    {
+      ary2 = make_contiguous(ary1, &is_new2, 0, 0);
+      if ( is_new1 && is_new2)
+      {
+        Py_DECREF(ary1);
+      }
+      ary1 = ary2;
+    }
+    *is_new_object = is_new1 || is_new2;
+    return ary1;
+  }
+
+  /* Convert a given PyObject to a Fortran-ordered PyArrayObject of the
+   * specified type.  If the input object is not a Fortran-ordered
+   * PyArrayObject, a new one will be created and the new object flag
+   * will be set.
+   */
+  PyArrayObject* obj_to_array_fortran_allow_conversion(PyObject* input,
+                                                       int       typecode,
+                                                       int*      is_new_object)
+  {
+    int is_new1 = 0;
+    int is_new2 = 0;
+    PyArrayObject* ary2;
+    PyArrayObject* ary1 = obj_to_array_allow_conversion(input,
+                                                        typecode,
+                                                        &is_new1);
+    if (ary1)
+    {
+      ary2 = make_fortran(ary1, &is_new2);
+      if (is_new1 && is_new2)
+      {
+        Py_DECREF(ary1);
+      }
+      ary1 = ary2;
+    }
+    *is_new_object = is_new1 || is_new2;
+    return ary1;
+  }
+} /* end fragment */
+
+/**********************************************************************/
+
+%fragment("NumPy_Array_Requirements",
+          "header",
+          fragment="NumPy_Backward_Compatibility",
+          fragment="NumPy_Macros")
+{
+  /* Test whether a python object is contiguous.  If array is
+   * contiguous, return 1.  Otherwise, set the python error string and
+   * return 0.
+   */
+  int require_contiguous(PyArrayObject* ary)
+  {
+    int contiguous = 1;
+    if (!array_is_contiguous(ary))
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "Array must be contiguous.  A non-contiguous array was given");
+      contiguous = 0;
+    }
+    return contiguous;
+  }
+
+  /* Test whether a python object is (C_ or F_) contiguous.  If array is
+   * contiguous, return 1.  Otherwise, set the python error string and
+   * return 0.
+   */
+  int require_c_or_f_contiguous(PyArrayObject* ary)
+  {
+    int contiguous = 1;
+    if (!(array_is_contiguous(ary) || array_is_fortran(ary)))
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "Array must be contiguous (C_ or F_).  A non-contiguous array was given");
+      contiguous = 0;
+    }
+    return contiguous;
+  }
+
+  /* Require that a numpy array is not byte-swapped.  If the array is
+   * not byte-swapped, return 1.  Otherwise, set the python error string
+   * and return 0.
+   */
+  int require_native(PyArrayObject* ary)
+  {
+    int native = 1;
+    if (!array_is_native(ary))
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "Array must have native byteorder.  "
+                      "A byte-swapped array was given");
+      native = 0;
+    }
+    return native;
+  }
+
+  /* Require the given PyArrayObject to have a specified number of
+   * dimensions.  If the array has the specified number of dimensions,
+   * return 1.  Otherwise, set the python error string and return 0.
+   */
+  int require_dimensions(PyArrayObject* ary,
+                         int            exact_dimensions)
+  {
+    int success = 1;
+    if (array_numdims(ary) != exact_dimensions)
+    {
+      PyErr_Format(PyExc_TypeError,
+                   "Array must have %d dimensions.  Given array has %d dimensions",
+                   exact_dimensions,
+                   array_numdims(ary));
+      success = 0;
+    }
+    return success;
+  }
+
+  /* Require the given PyArrayObject to have one of a list of specified
+   * number of dimensions.  If the array has one of the specified number
+   * of dimensions, return 1.  Otherwise, set the python error string
+   * and return 0.
+   */
+  int require_dimensions_n(PyArrayObject* ary,
+                           int*           exact_dimensions,
+                           int            n)
+  {
+    int success = 0;
+    int i;
+    char dims_str[255] = "";
+    char s[255];
+    for (i = 0; i < n && !success; i++)
+    {
+      if (array_numdims(ary) == exact_dimensions[i])
+      {
+        success = 1;
+      }
+    }
+    if (!success)
+    {
+      for (i = 0; i < n-1; i++)
+      {
+        sprintf(s, "%d, ", exact_dimensions[i]);
+        strcat(dims_str,s);
+      }
+      sprintf(s, " or %d", exact_dimensions[n-1]);
+      strcat(dims_str,s);
+      PyErr_Format(PyExc_TypeError,
+                   "Array must have %s dimensions.  Given array has %d dimensions",
+                   dims_str,
+                   array_numdims(ary));
+    }
+    return success;
+  }
+
+  /* Require the given PyArrayObject to have a specified shape.  If the
+   * array has the specified shape, return 1.  Otherwise, set the python
+   * error string and return 0.
+   */
+  int require_size(PyArrayObject* ary,
+                   npy_intp*      size,
+                   int            n)
+  {
+    int i;
+    int success = 1;
+    size_t len;
+    char desired_dims[255] = "[";
+    char s[255];
+    char actual_dims[255] = "[";
+    for(i=0; i < n;i++)
+    {
+      if (size[i] != -1 &&  size[i] != array_size(ary,i))
+      {
+        success = 0;
+      }
+    }
+    if (!success)
+    {
+      for (i = 0; i < n; i++)
+      {
+        if (size[i] == -1)
+        {
+          sprintf(s, "*,");
+        }
+        else
+        {
+          sprintf(s, "%ld,", (long int)size[i]);
+        }
+        strcat(desired_dims,s);
+      }
+      len = strlen(desired_dims);
+      desired_dims[len-1] = ']';
+      for (i = 0; i < n; i++)
+      {
+        sprintf(s, "%ld,", (long int)array_size(ary,i));
+        strcat(actual_dims,s);
+      }
+      len = strlen(actual_dims);
+      actual_dims[len-1] = ']';
+      PyErr_Format(PyExc_TypeError,
+                   "Array must have shape of %s.  Given array has shape of %s",
+                   desired_dims,
+                   actual_dims);
+    }
+    return success;
+  }
+
+  /* Require the given PyArrayObject to be Fortran ordered.  If the
+   * the PyArrayObject is already Fortran ordered, do nothing.  Else,
+   * set the Fortran ordering flag and recompute the strides.
+   */
+  int require_fortran(PyArrayObject* ary)
+  {
+    int success = 1;
+    int nd = array_numdims(ary);
+    int i;
+    npy_intp * strides = array_strides(ary);
+    if (array_is_fortran(ary)) return success;
+    int n_non_one = 0;
+    /* Set the Fortran ordered flag */
+    const npy_intp *dims = array_dimensions(ary);
+    for (i=0; i < nd; ++i)
+      n_non_one += (dims[i] != 1) ? 1 : 0;
+    if (n_non_one > 1)
+      array_clearflags(ary,NPY_ARRAY_CARRAY);
+    array_enableflags(ary,NPY_ARRAY_FARRAY);
+    /* Recompute the strides */
+    strides[0] = strides[nd-1];
+    for (i=1; i < nd; ++i)
+      strides[i] = strides[i-1] * array_size(ary,i-1);
+    return success;
+  }
+}
+
+/* Combine all NumPy fragments into one for convenience */
+%fragment("NumPy_Fragments",
+          "header",
+          fragment="NumPy_Backward_Compatibility",
+          fragment="NumPy_Macros",
+          fragment="NumPy_Utilities",
+          fragment="NumPy_Object_to_Array",
+          fragment="NumPy_Array_Requirements")
+{
+}
+
+/* End John Hunter translation (with modifications by Bill Spotz)
+ */
+
+/* %numpy_typemaps() macro
+ *
+ * This macro defines a family of 75 typemaps that allow C arguments
+ * of the form
+ *
+ *    1. (DATA_TYPE IN_ARRAY1[ANY])
+ *    2. (DATA_TYPE* IN_ARRAY1, DIM_TYPE DIM1)
+ *    3. (DIM_TYPE DIM1, DATA_TYPE* IN_ARRAY1)
+ *
+ *    4. (DATA_TYPE IN_ARRAY2[ANY][ANY])
+ *    5. (DATA_TYPE* IN_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ *    6. (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_ARRAY2)
+ *    7. (DATA_TYPE* IN_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ *    8. (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_FARRAY2)
+ *
+ *    9. (DATA_TYPE IN_ARRAY3[ANY][ANY][ANY])
+ *   10. (DATA_TYPE* IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+ *   11. (DATA_TYPE** IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+ *   12. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_ARRAY3)
+ *   13. (DATA_TYPE* IN_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+ *   14. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_FARRAY3)
+ *
+ *   15. (DATA_TYPE IN_ARRAY4[ANY][ANY][ANY][ANY])
+ *   16. (DATA_TYPE* IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+ *   17. (DATA_TYPE** IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+ *   18. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, , DIM_TYPE DIM4, DATA_TYPE* IN_ARRAY4)
+ *   19. (DATA_TYPE* IN_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+ *   20. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* IN_FARRAY4)
+ *
+ *   21. (DATA_TYPE INPLACE_ARRAY1[ANY])
+ *   22. (DATA_TYPE* INPLACE_ARRAY1, DIM_TYPE DIM1)
+ *   23. (DIM_TYPE DIM1, DATA_TYPE* INPLACE_ARRAY1)
+ *
+ *   24. (DATA_TYPE INPLACE_ARRAY2[ANY][ANY])
+ *   25. (DATA_TYPE* INPLACE_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ *   26. (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_ARRAY2)
+ *   27. (DATA_TYPE* INPLACE_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ *   28. (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_FARRAY2)
+ *
+ *   29. (DATA_TYPE INPLACE_ARRAY3[ANY][ANY][ANY])
+ *   30. (DATA_TYPE* INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+ *   31. (DATA_TYPE** INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+ *   32. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* INPLACE_ARRAY3)
+ *   33. (DATA_TYPE* INPLACE_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+ *   34. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* INPLACE_FARRAY3)
+ *
+ *   35. (DATA_TYPE INPLACE_ARRAY4[ANY][ANY][ANY][ANY])
+ *   36. (DATA_TYPE* INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+ *   37. (DATA_TYPE** INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+ *   38. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* INPLACE_ARRAY4)
+ *   39. (DATA_TYPE* INPLACE_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+ *   40. (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* INPLACE_FARRAY4)
+ *
+ *   41. (DATA_TYPE ARGOUT_ARRAY1[ANY])
+ *   42. (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
+ *   43. (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
+ *
+ *   44. (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
+ *
+ *   45. (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
+ *
+ *   46. (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
+ *
+ *   47. (DATA_TYPE** ARGOUTVIEW_ARRAY1, DIM_TYPE* DIM1)
+ *   48. (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEW_ARRAY1)
+ *
+ *   49. (DATA_TYPE** ARGOUTVIEW_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ *   50. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_ARRAY2)
+ *   51. (DATA_TYPE** ARGOUTVIEW_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ *   52. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_FARRAY2)
+ *
+ *   53. (DATA_TYPE** ARGOUTVIEW_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+ *   54. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEW_ARRAY3)
+ *   55. (DATA_TYPE** ARGOUTVIEW_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+ *   56. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEW_FARRAY3)
+ *
+ *   57. (DATA_TYPE** ARGOUTVIEW_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ *   58. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEW_ARRAY4)
+ *   59. (DATA_TYPE** ARGOUTVIEW_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ *   60. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEW_FARRAY4)
+ *
+ *   61. (DATA_TYPE** ARGOUTVIEWM_ARRAY1, DIM_TYPE* DIM1)
+ *   62. (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEWM_ARRAY1)
+ *
+ *   63. (DATA_TYPE** ARGOUTVIEWM_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ *   64. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_ARRAY2)
+ *   65. (DATA_TYPE** ARGOUTVIEWM_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ *   66. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_FARRAY2)
+ *
+ *   67. (DATA_TYPE** ARGOUTVIEWM_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+ *   68. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEWM_ARRAY3)
+ *   69. (DATA_TYPE** ARGOUTVIEWM_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+ *   70. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEWM_FARRAY3)
+ *
+ *   71. (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ *   72. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_ARRAY4)
+ *   73. (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ *   74. (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_FARRAY4)
+ *
+ *   75. (DATA_TYPE* INPLACE_ARRAY_FLAT, DIM_TYPE DIM_FLAT)
+ *
+ * where "DATA_TYPE" is any type supported by the NumPy module, and
+ * "DIM_TYPE" is any int-like type suitable for specifying dimensions.
+ * The difference between "ARRAY" typemaps and "FARRAY" typemaps is
+ * that the "FARRAY" typemaps expect Fortran ordering of
+ * multidimensional arrays.  In python, the dimensions will not need
+ * to be specified (except for the "DATA_TYPE* ARGOUT_ARRAY1"
+ * typemaps).  The IN_ARRAYs can be a numpy array or any sequence that
+ * can be converted to a numpy array of the specified type.  The
+ * INPLACE_ARRAYs must be numpy arrays of the appropriate type.  The
+ * ARGOUT_ARRAYs will be returned as new numpy arrays of the
+ * appropriate type.
+ *
+ * These typemaps can be applied to existing functions using the
+ * %apply directive.  For example:
+ *
+ *     %apply (double* IN_ARRAY1, int DIM1) {(double* series, int length)};
+ *     double prod(double* series, int length);
+ *
+ *     %apply (int DIM1, int DIM2, double* INPLACE_ARRAY2)
+ *           {(int rows, int cols, double* matrix        )};
+ *     void floor(int rows, int cols, double* matrix, double f);
+ *
+ *     %apply (double IN_ARRAY3[ANY][ANY][ANY])
+ *           {(double tensor[2][2][2]         )};
+ *     %apply (double ARGOUT_ARRAY3[ANY][ANY][ANY])
+ *           {(double low[2][2][2]                )};
+ *     %apply (double ARGOUT_ARRAY3[ANY][ANY][ANY])
+ *           {(double upp[2][2][2]                )};
+ *     void luSplit(double tensor[2][2][2],
+ *                  double low[2][2][2],
+ *                  double upp[2][2][2]    );
+ *
+ * or directly with
+ *
+ *     double prod(double* IN_ARRAY1, int DIM1);
+ *
+ *     void floor(int DIM1, int DIM2, double* INPLACE_ARRAY2, double f);
+ *
+ *     void luSplit(double IN_ARRAY3[ANY][ANY][ANY],
+ *                  double ARGOUT_ARRAY3[ANY][ANY][ANY],
+ *                  double ARGOUT_ARRAY3[ANY][ANY][ANY]);
+ */
+
+%define %numpy_typemaps(DATA_TYPE, DATA_TYPECODE, DIM_TYPE)
+
+/************************/
+/* Input Array Typemaps */
+/************************/
+
+/* Typemap suite for (DATA_TYPE IN_ARRAY1[ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE IN_ARRAY1[ANY])
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE IN_ARRAY1[ANY])
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[1] = { $1_dim0 };
+  array = obj_to_array_contiguous_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 1) ||
+      !require_size(array, size, 1)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(freearg)
+  (DATA_TYPE IN_ARRAY1[ANY])
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE* IN_ARRAY1, DIM_TYPE DIM1)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* IN_ARRAY1, DIM_TYPE DIM1)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* IN_ARRAY1, DIM_TYPE DIM1)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[1] = { -1 };
+  array = obj_to_array_contiguous_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 1) ||
+      !require_size(array, size, 1)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+}
+%typemap(freearg)
+  (DATA_TYPE* IN_ARRAY1, DIM_TYPE DIM1)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DATA_TYPE* IN_ARRAY1)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DATA_TYPE* IN_ARRAY1)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DATA_TYPE* IN_ARRAY1)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[1] = {-1};
+  array = obj_to_array_contiguous_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 1) ||
+      !require_size(array, size, 1)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DATA_TYPE*) array_data(array);
+}
+%typemap(freearg)
+  (DIM_TYPE DIM1, DATA_TYPE* IN_ARRAY1)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE IN_ARRAY2[ANY][ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE IN_ARRAY2[ANY][ANY])
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE IN_ARRAY2[ANY][ANY])
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[2] = { $1_dim0, $1_dim1 };
+  array = obj_to_array_contiguous_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 2) ||
+      !require_size(array, size, 2)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(freearg)
+  (DATA_TYPE IN_ARRAY2[ANY][ANY])
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE* IN_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* IN_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* IN_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[2] = { -1, -1 };
+  array = obj_to_array_contiguous_allow_conversion($input, DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 2) ||
+      !require_size(array, size, 2)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+}
+%typemap(freearg)
+  (DATA_TYPE* IN_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_ARRAY2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_ARRAY2)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_ARRAY2)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[2] = { -1, -1 };
+  array = obj_to_array_contiguous_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 2) ||
+      !require_size(array, size, 2)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DATA_TYPE*) array_data(array);
+}
+%typemap(freearg)
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_ARRAY2)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE* IN_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* IN_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* IN_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[2] = { -1, -1 };
+  array = obj_to_array_fortran_allow_conversion($input,
+                                                DATA_TYPECODE,
+                                                &is_new_object);
+  if (!array || !require_dimensions(array, 2) ||
+      !require_size(array, size, 2) || !require_fortran(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+}
+%typemap(freearg)
+  (DATA_TYPE* IN_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_FARRAY2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_FARRAY2)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_FARRAY2)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[2] = { -1, -1 };
+  array = obj_to_array_fortran_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 2) ||
+      !require_size(array, size, 2) || !require_fortran(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DATA_TYPE*) array_data(array);
+}
+%typemap(freearg)
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* IN_FARRAY2)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE IN_ARRAY3[ANY][ANY][ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE IN_ARRAY3[ANY][ANY][ANY])
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE IN_ARRAY3[ANY][ANY][ANY])
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[3] = { $1_dim0, $1_dim1, $1_dim2 };
+  array = obj_to_array_contiguous_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 3) ||
+      !require_size(array, size, 3)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(freearg)
+  (DATA_TYPE IN_ARRAY3[ANY][ANY][ANY])
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE* IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[3] = { -1, -1, -1 };
+  array = obj_to_array_contiguous_allow_conversion($input, DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 3) ||
+      !require_size(array, size, 3)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+}
+%typemap(freearg)
+  (DATA_TYPE* IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE** IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE** IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  /* for now, only concerned with lists */
+  $1 = PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE** IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+  (DATA_TYPE** array=NULL, PyArrayObject** object_array=NULL, int* is_new_object_array=NULL)
+{
+  npy_intp size[2] = { -1, -1 };
+  PyArrayObject* temp_array;
+  Py_ssize_t i;
+  int is_new_object;
+
+  /* length of the list */
+  $2 = PyList_Size($input);
+
+  /* the arrays */
+  array = (DATA_TYPE **)malloc($2*sizeof(DATA_TYPE *));
+  object_array = (PyArrayObject **)calloc($2,sizeof(PyArrayObject *));
+  is_new_object_array = (int *)calloc($2,sizeof(int));
+
+  if (array == NULL || object_array == NULL || is_new_object_array == NULL)
+  {
+    SWIG_fail;
+  }
+
+  for (i=0; i<$2; i++)
+  {
+    temp_array = obj_to_array_contiguous_allow_conversion(PySequence_GetItem($input,i), DATA_TYPECODE, &is_new_object);
+
+    /* the new array must be stored so that it can be destroyed in freearg */
+    object_array[i] = temp_array;
+    is_new_object_array[i] = is_new_object;
+
+    if (!temp_array || !require_dimensions(temp_array, 2)) SWIG_fail;
+
+    /* store the size of the first array in the list, then use that for comparison. */
+    if (i == 0)
+    {
+      size[0] = array_size(temp_array,0);
+      size[1] = array_size(temp_array,1);
+    }
+
+    if (!require_size(temp_array, size, 2)) SWIG_fail;
+
+    array[i] = (DATA_TYPE*) array_data(temp_array);
+  }
+
+  $1 = (DATA_TYPE**) array;
+  $3 = (DIM_TYPE) size[0];
+  $4 = (DIM_TYPE) size[1];
+}
+%typemap(freearg)
+  (DATA_TYPE** IN_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  Py_ssize_t i;
+
+  if (array$argnum!=NULL) free(array$argnum);
+
+  /*freeing the individual arrays if needed */
+  if (object_array$argnum!=NULL)
+  {
+    if (is_new_object_array$argnum!=NULL)
+    {
+      for (i=0; i<$2; i++)
+      {
+        if (object_array$argnum[i] != NULL && is_new_object_array$argnum[i])
+        { Py_DECREF(object_array$argnum[i]); }
+      }
+      free(is_new_object_array$argnum);
+    }
+    free(object_array$argnum);
+  }
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3,
+ *                    DATA_TYPE* IN_ARRAY3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_ARRAY3)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_ARRAY3)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[3] = { -1, -1, -1 };
+  array = obj_to_array_contiguous_allow_conversion($input, DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 3) ||
+      !require_size(array, size, 3)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DATA_TYPE*) array_data(array);
+}
+%typemap(freearg)
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_ARRAY3)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE* IN_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* IN_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* IN_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[3] = { -1, -1, -1 };
+  array = obj_to_array_fortran_allow_conversion($input, DATA_TYPECODE,
+                                                &is_new_object);
+  if (!array || !require_dimensions(array, 3) ||
+      !require_size(array, size, 3) | !require_fortran(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+}
+%typemap(freearg)
+  (DATA_TYPE* IN_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3,
+ *                    DATA_TYPE* IN_FARRAY3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_FARRAY3)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_FARRAY3)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[3] = { -1, -1, -1 };
+  array = obj_to_array_fortran_allow_conversion($input,
+                                                   DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 3) ||
+      !require_size(array, size, 3) || !require_fortran(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DATA_TYPE*) array_data(array);
+}
+%typemap(freearg)
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* IN_FARRAY3)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE IN_ARRAY4[ANY][ANY][ANY][ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE IN_ARRAY4[ANY][ANY][ANY][ANY])
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE IN_ARRAY4[ANY][ANY][ANY][ANY])
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[4] = { $1_dim0, $1_dim1, $1_dim2 , $1_dim3};
+  array = obj_to_array_contiguous_allow_conversion($input, DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 4) ||
+      !require_size(array, size, 4)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(freearg)
+  (DATA_TYPE IN_ARRAY4[ANY][ANY][ANY][ANY])
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE* IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3, DIM_TYPE DIM4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[4] = { -1, -1, -1, -1 };
+  array = obj_to_array_contiguous_allow_conversion($input, DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 4) ||
+      !require_size(array, size, 4)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+  $5 = (DIM_TYPE) array_size(array,3);
+}
+%typemap(freearg)
+  (DATA_TYPE* IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE** IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3, DIM_TYPE DIM4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE** IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  /* for now, only concerned with lists */
+  $1 = PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE** IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+  (DATA_TYPE** array=NULL, PyArrayObject** object_array=NULL, int* is_new_object_array=NULL)
+{
+  npy_intp size[3] = { -1, -1, -1 };
+  PyArrayObject* temp_array;
+  Py_ssize_t i;
+  int is_new_object;
+
+  /* length of the list */
+  $2 = PyList_Size($input);
+
+  /* the arrays */
+  array = (DATA_TYPE **)malloc($2*sizeof(DATA_TYPE *));
+  object_array = (PyArrayObject **)calloc($2,sizeof(PyArrayObject *));
+  is_new_object_array = (int *)calloc($2,sizeof(int));
+
+  if (array == NULL || object_array == NULL || is_new_object_array == NULL)
+  {
+    SWIG_fail;
+  }
+
+  for (i=0; i<$2; i++)
+  {
+    temp_array = obj_to_array_contiguous_allow_conversion(PySequence_GetItem($input,i), DATA_TYPECODE, &is_new_object);
+
+    /* the new array must be stored so that it can be destroyed in freearg */
+    object_array[i] = temp_array;
+    is_new_object_array[i] = is_new_object;
+
+    if (!temp_array || !require_dimensions(temp_array, 3)) SWIG_fail;
+
+    /* store the size of the first array in the list, then use that for comparison. */
+    if (i == 0)
+    {
+      size[0] = array_size(temp_array,0);
+      size[1] = array_size(temp_array,1);
+      size[2] = array_size(temp_array,2);
+    }
+
+    if (!require_size(temp_array, size, 3)) SWIG_fail;
+
+    array[i] = (DATA_TYPE*) array_data(temp_array);
+  }
+
+  $1 = (DATA_TYPE**) array;
+  $3 = (DIM_TYPE) size[0];
+  $4 = (DIM_TYPE) size[1];
+  $5 = (DIM_TYPE) size[2];
+}
+%typemap(freearg)
+  (DATA_TYPE** IN_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  Py_ssize_t i;
+
+  if (array$argnum!=NULL) free(array$argnum);
+
+  /*freeing the individual arrays if needed */
+  if (object_array$argnum!=NULL)
+  {
+    if (is_new_object_array$argnum!=NULL)
+    {
+      for (i=0; i<$2; i++)
+      {
+        if (object_array$argnum[i] != NULL && is_new_object_array$argnum[i])
+        { Py_DECREF(object_array$argnum[i]); }
+      }
+      free(is_new_object_array$argnum);
+    }
+    free(object_array$argnum);
+  }
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4,
+ *                    DATA_TYPE* IN_ARRAY4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* IN_ARRAY4)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* IN_ARRAY4)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[4] = { -1, -1, -1 , -1};
+  array = obj_to_array_contiguous_allow_conversion($input, DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 4) ||
+      !require_size(array, size, 4)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DIM_TYPE) array_size(array,3);
+  $5 = (DATA_TYPE*) array_data(array);
+}
+%typemap(freearg)
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* IN_ARRAY4)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DATA_TYPE* IN_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3, DIM_TYPE DIM4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* IN_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* IN_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[4] = { -1, -1, -1, -1 };
+  array = obj_to_array_fortran_allow_conversion($input, DATA_TYPECODE,
+                                                &is_new_object);
+  if (!array || !require_dimensions(array, 4) ||
+      !require_size(array, size, 4) | !require_fortran(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+  $5 = (DIM_TYPE) array_size(array,3);
+}
+%typemap(freearg)
+  (DATA_TYPE* IN_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4,
+ *                    DATA_TYPE* IN_FARRAY4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* IN_FARRAY4)
+{
+  $1 = is_array($input) || PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* IN_FARRAY4)
+  (PyArrayObject* array=NULL, int is_new_object=0)
+{
+  npy_intp size[4] = { -1, -1, -1 , -1 };
+  array = obj_to_array_fortran_allow_conversion($input, DATA_TYPECODE,
+                                                   &is_new_object);
+  if (!array || !require_dimensions(array, 4) ||
+      !require_size(array, size, 4) || !require_fortran(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DIM_TYPE) array_size(array,3);
+  $5 = (DATA_TYPE*) array_data(array);
+}
+%typemap(freearg)
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* IN_FARRAY4)
+{
+  if (is_new_object$argnum && array$argnum)
+    { Py_DECREF(array$argnum); }
+}
+
+/***************************/
+/* In-Place Array Typemaps */
+/***************************/
+
+/* Typemap suite for (DATA_TYPE INPLACE_ARRAY1[ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE INPLACE_ARRAY1[ANY])
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE INPLACE_ARRAY1[ANY])
+  (PyArrayObject* array=NULL)
+{
+  npy_intp size[1] = { $1_dim0 };
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,1) || !require_size(array, size, 1) ||
+      !require_contiguous(array) || !require_native(array)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE* INPLACE_ARRAY1, DIM_TYPE DIM1)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_ARRAY1, DIM_TYPE DIM1)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_ARRAY1, DIM_TYPE DIM1)
+  (PyArrayObject* array=NULL, int i=1)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,1) || !require_contiguous(array)
+      || !require_native(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = 1;
+  for (i=0; i < array_numdims(array); ++i) $2 *= array_size(array,i);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DATA_TYPE* INPLACE_ARRAY1)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DATA_TYPE* INPLACE_ARRAY1)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DATA_TYPE* INPLACE_ARRAY1)
+  (PyArrayObject* array=NULL, int i=0)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,1) || !require_contiguous(array)
+      || !require_native(array)) SWIG_fail;
+  $1 = 1;
+  for (i=0; i < array_numdims(array); ++i) $1 *= array_size(array,i);
+  $2 = (DATA_TYPE*) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE INPLACE_ARRAY2[ANY][ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE INPLACE_ARRAY2[ANY][ANY])
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE INPLACE_ARRAY2[ANY][ANY])
+  (PyArrayObject* array=NULL)
+{
+  npy_intp size[2] = { $1_dim0, $1_dim1 };
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,2) || !require_size(array, size, 2) ||
+      !require_contiguous(array) || !require_native(array)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE* INPLACE_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_ARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,2) || !require_contiguous(array)
+      || !require_native(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_ARRAY2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_ARRAY2)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_ARRAY2)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,2) || !require_contiguous(array) ||
+      !require_native(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DATA_TYPE*) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE* INPLACE_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_FARRAY2, DIM_TYPE DIM1, DIM_TYPE DIM2)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,2) || !require_contiguous(array)
+      || !require_native(array) || !require_fortran(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_FARRAY2)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_FARRAY2)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DATA_TYPE* INPLACE_FARRAY2)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,2) || !require_contiguous(array) ||
+      !require_native(array) || !require_fortran(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DATA_TYPE*) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE INPLACE_ARRAY3[ANY][ANY][ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE INPLACE_ARRAY3[ANY][ANY][ANY])
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE INPLACE_ARRAY3[ANY][ANY][ANY])
+  (PyArrayObject* array=NULL)
+{
+  npy_intp size[3] = { $1_dim0, $1_dim1, $1_dim2 };
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,3) || !require_size(array, size, 3) ||
+      !require_contiguous(array) || !require_native(array)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE* INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,3) || !require_contiguous(array) ||
+      !require_native(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+}
+
+/* Typemap suite for (DATA_TYPE** INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE** INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  $1 = PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE** INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+  (DATA_TYPE** array=NULL, PyArrayObject** object_array=NULL)
+{
+  npy_intp size[2] = { -1, -1 };
+  PyArrayObject* temp_array;
+  Py_ssize_t i;
+
+  /* length of the list */
+  $2 = PyList_Size($input);
+
+  /* the arrays */
+  array = (DATA_TYPE **)malloc($2*sizeof(DATA_TYPE *));
+  object_array = (PyArrayObject **)calloc($2,sizeof(PyArrayObject *));
+
+  if (array == NULL || object_array == NULL)
+  {
+    SWIG_fail;
+  }
+
+  for (i=0; i<$2; i++)
+  {
+    temp_array = obj_to_array_no_conversion(PySequence_GetItem($input,i), DATA_TYPECODE);
+
+    /* the new array must be stored so that it can be destroyed in freearg */
+    object_array[i] = temp_array;
+
+    if ( !temp_array || !require_dimensions(temp_array, 2) ||
+      !require_contiguous(temp_array) ||
+      !require_native(temp_array) ||
+      !PyArray_EquivTypenums(array_type(temp_array), DATA_TYPECODE)
+    ) SWIG_fail;
+
+    /* store the size of the first array in the list, then use that for comparison. */
+    if (i == 0)
+    {
+      size[0] = array_size(temp_array,0);
+      size[1] = array_size(temp_array,1);
+    }
+
+    if (!require_size(temp_array, size, 2)) SWIG_fail;
+
+    array[i] = (DATA_TYPE*) array_data(temp_array);
+  }
+
+  $1 = (DATA_TYPE**) array;
+  $3 = (DIM_TYPE) size[0];
+  $4 = (DIM_TYPE) size[1];
+}
+%typemap(freearg)
+  (DATA_TYPE** INPLACE_ARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  if (array$argnum!=NULL) free(array$argnum);
+  if (object_array$argnum!=NULL) free(object_array$argnum);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3,
+ *                    DATA_TYPE* INPLACE_ARRAY3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* INPLACE_ARRAY3)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* INPLACE_ARRAY3)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,3) || !require_contiguous(array)
+      || !require_native(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DATA_TYPE*) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE* INPLACE_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_FARRAY3, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,3) || !require_contiguous(array) ||
+      !require_native(array) || !require_fortran(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3,
+ *                    DATA_TYPE* INPLACE_FARRAY3)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* INPLACE_FARRAY3)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DATA_TYPE* INPLACE_FARRAY3)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,3) || !require_contiguous(array)
+      || !require_native(array) || !require_fortran(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DATA_TYPE*) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE INPLACE_ARRAY4[ANY][ANY][ANY][ANY])
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE INPLACE_ARRAY4[ANY][ANY][ANY][ANY])
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE INPLACE_ARRAY4[ANY][ANY][ANY][ANY])
+  (PyArrayObject* array=NULL)
+{
+  npy_intp size[4] = { $1_dim0, $1_dim1, $1_dim2 , $1_dim3 };
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,4) || !require_size(array, size, 4) ||
+      !require_contiguous(array) || !require_native(array)) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE* INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3, DIM_TYPE DIM4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,4) || !require_contiguous(array) ||
+      !require_native(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+  $5 = (DIM_TYPE) array_size(array,3);
+}
+
+/* Typemap suite for (DATA_TYPE** INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3, DIM_TYPE DIM4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE** INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  $1 = PySequence_Check($input);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE** INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+  (DATA_TYPE** array=NULL, PyArrayObject** object_array=NULL)
+{
+  npy_intp size[3] = { -1, -1, -1 };
+  PyArrayObject* temp_array;
+  Py_ssize_t i;
+
+  /* length of the list */
+  $2 = PyList_Size($input);
+
+  /* the arrays */
+  array = (DATA_TYPE **)malloc($2*sizeof(DATA_TYPE *));
+  object_array = (PyArrayObject **)calloc($2,sizeof(PyArrayObject *));
+
+  if (array == NULL || object_array == NULL)
+  {
+    SWIG_fail;
+  }
+
+  for (i=0; i<$2; i++)
+  {
+    temp_array = obj_to_array_no_conversion(PySequence_GetItem($input,i), DATA_TYPECODE);
+
+    /* the new array must be stored so that it can be destroyed in freearg */
+    object_array[i] = temp_array;
+
+    if ( !temp_array || !require_dimensions(temp_array, 3) ||
+      !require_contiguous(temp_array) ||
+      !require_native(temp_array) ||
+      !PyArray_EquivTypenums(array_type(temp_array), DATA_TYPECODE)
+    ) SWIG_fail;
+
+    /* store the size of the first array in the list, then use that for comparison. */
+    if (i == 0)
+    {
+      size[0] = array_size(temp_array,0);
+      size[1] = array_size(temp_array,1);
+      size[2] = array_size(temp_array,2);
+    }
+
+    if (!require_size(temp_array, size, 3)) SWIG_fail;
+
+    array[i] = (DATA_TYPE*) array_data(temp_array);
+  }
+
+  $1 = (DATA_TYPE**) array;
+  $3 = (DIM_TYPE) size[0];
+  $4 = (DIM_TYPE) size[1];
+  $5 = (DIM_TYPE) size[2];
+}
+%typemap(freearg)
+  (DATA_TYPE** INPLACE_ARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  if (array$argnum!=NULL) free(array$argnum);
+  if (object_array$argnum!=NULL) free(object_array$argnum);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4,
+ *                    DATA_TYPE* INPLACE_ARRAY4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* INPLACE_ARRAY4)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* INPLACE_ARRAY4)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,4) || !require_contiguous(array)
+      || !require_native(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DIM_TYPE) array_size(array,3);
+  $5 = (DATA_TYPE*) array_data(array);
+}
+
+/* Typemap suite for (DATA_TYPE* INPLACE_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2,
+ *                    DIM_TYPE DIM3, DIM_TYPE DIM4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_FARRAY4, DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,4) || !require_contiguous(array) ||
+      !require_native(array) || !require_fortran(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = (DIM_TYPE) array_size(array,0);
+  $3 = (DIM_TYPE) array_size(array,1);
+  $4 = (DIM_TYPE) array_size(array,2);
+  $5 = (DIM_TYPE) array_size(array,3);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3,
+ *                    DATA_TYPE* INPLACE_FARRAY4)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* INPLACE_FARRAY4)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DIM_TYPE DIM2, DIM_TYPE DIM3, DIM_TYPE DIM4, DATA_TYPE* INPLACE_FARRAY4)
+  (PyArrayObject* array=NULL)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_dimensions(array,4) || !require_contiguous(array)
+      || !require_native(array) || !require_fortran(array)) SWIG_fail;
+  $1 = (DIM_TYPE) array_size(array,0);
+  $2 = (DIM_TYPE) array_size(array,1);
+  $3 = (DIM_TYPE) array_size(array,2);
+  $4 = (DIM_TYPE) array_size(array,3);
+  $5 = (DATA_TYPE*) array_data(array);
+}
+
+/*************************/
+/* Argout Array Typemaps */
+/*************************/
+
+/* Typemap suite for (DATA_TYPE ARGOUT_ARRAY1[ANY])
+ */
+%typemap(in,numinputs=0,
+         fragment="NumPy_Backward_Compatibility,NumPy_Macros")
+  (DATA_TYPE ARGOUT_ARRAY1[ANY])
+  (PyObject* array = NULL)
+{
+  npy_intp dims[1] = { $1_dim0 };
+  array = PyArray_SimpleNew(1, dims, DATA_TYPECODE);
+  if (!array) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(argout)
+  (DATA_TYPE ARGOUT_ARRAY1[ANY])
+{
+  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+}
+
+/* Typemap suite for (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
+ */
+%typemap(in,numinputs=1,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
+  (PyObject* array = NULL)
+{
+  npy_intp dims[1];
+  if (!PyLong_Check($input))
+  {
+    const char* typestring = pytype_string($input);
+    PyErr_Format(PyExc_TypeError,
+                 "Int dimension expected.  '%s' given.",
+                 typestring);
+    SWIG_fail;
+  }
+  $2 = (DIM_TYPE) PyLong_AsSsize_t($input);
+  if ($2 == -1 && PyErr_Occurred()) SWIG_fail;
+  dims[0] = (npy_intp) $2;
+  array = PyArray_SimpleNew(1, dims, DATA_TYPECODE);
+  if (!array) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+}
+%typemap(argout)
+  (DATA_TYPE* ARGOUT_ARRAY1, DIM_TYPE DIM1)
+{
+  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+}
+
+/* Typemap suite for (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
+ */
+%typemap(in,numinputs=1,
+         fragment="NumPy_Fragments")
+  (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
+  (PyObject* array = NULL)
+{
+  npy_intp dims[1];
+  if (!PyLong_Check($input))
+  {
+    const char* typestring = pytype_string($input);
+    PyErr_Format(PyExc_TypeError,
+                 "Int dimension expected.  '%s' given.",
+                 typestring);
+    SWIG_fail;
+  }
+  $1 = (DIM_TYPE) PyLong_AsSsize_t($input);
+  if ($1 == -1 && PyErr_Occurred()) SWIG_fail;
+  dims[0] = (npy_intp) $1;
+  array = PyArray_SimpleNew(1, dims, DATA_TYPECODE);
+  if (!array) SWIG_fail;
+  $2 = (DATA_TYPE*) array_data(array);
+}
+%typemap(argout)
+  (DIM_TYPE DIM1, DATA_TYPE* ARGOUT_ARRAY1)
+{
+  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+}
+
+/* Typemap suite for (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
+ */
+%typemap(in,numinputs=0,
+         fragment="NumPy_Backward_Compatibility,NumPy_Macros")
+  (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
+  (PyObject* array = NULL)
+{
+  npy_intp dims[2] = { $1_dim0, $1_dim1 };
+  array = PyArray_SimpleNew(2, dims, DATA_TYPECODE);
+  if (!array) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(argout)
+  (DATA_TYPE ARGOUT_ARRAY2[ANY][ANY])
+{
+  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+}
+
+/* Typemap suite for (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
+ */
+%typemap(in,numinputs=0,
+         fragment="NumPy_Backward_Compatibility,NumPy_Macros")
+  (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
+  (PyObject* array = NULL)
+{
+  npy_intp dims[3] = { $1_dim0, $1_dim1, $1_dim2 };
+  array = PyArray_SimpleNew(3, dims, DATA_TYPECODE);
+  if (!array) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(argout)
+  (DATA_TYPE ARGOUT_ARRAY3[ANY][ANY][ANY])
+{
+  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+}
+
+/* Typemap suite for (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
+ */
+%typemap(in,numinputs=0,
+         fragment="NumPy_Backward_Compatibility,NumPy_Macros")
+  (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
+  (PyObject* array = NULL)
+{
+  npy_intp dims[4] = { $1_dim0, $1_dim1, $1_dim2, $1_dim3 };
+  array = PyArray_SimpleNew(4, dims, DATA_TYPECODE);
+  if (!array) SWIG_fail;
+  $1 = ($1_ltype) array_data(array);
+}
+%typemap(argout)
+  (DATA_TYPE ARGOUT_ARRAY4[ANY][ANY][ANY][ANY])
+{
+  $result = SWIG_Python_AppendOutput($result,(PyObject*)array$argnum);
+}
+
+/*****************************/
+/* Argoutview Array Typemaps */
+/*****************************/
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY1, DIM_TYPE* DIM1)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEW_ARRAY1, DIM_TYPE* DIM1    )
+  (DATA_TYPE*  data_temp = NULL , DIM_TYPE  dim_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DATA_TYPE** ARGOUTVIEW_ARRAY1, DIM_TYPE* DIM1)
+{
+  npy_intp dims[1] = { *$2 };
+  PyObject* obj = PyArray_SimpleNewFromData(1, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEW_ARRAY1)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DATA_TYPE** ARGOUTVIEW_ARRAY1)
+  (DIM_TYPE  dim_temp, DATA_TYPE*  data_temp = NULL )
+{
+  $1 = &dim_temp;
+  $2 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEW_ARRAY1)
+{
+  npy_intp dims[1] = { *$1 };
+  PyObject* obj = PyArray_SimpleNewFromData(1, dims, DATA_TYPECODE, (void*)(*$2));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEW_ARRAY2, DIM_TYPE* DIM1     , DIM_TYPE* DIM2     )
+  (DATA_TYPE*  data_temp = NULL , DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DATA_TYPE** ARGOUTVIEW_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+{
+  npy_intp dims[2] = { *$2, *$3 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_ARRAY2)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1     , DIM_TYPE* DIM2     , DATA_TYPE** ARGOUTVIEW_ARRAY2)
+  (DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp, DATA_TYPE*  data_temp = NULL )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_ARRAY2)
+{
+  npy_intp dims[2] = { *$1, *$2 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$3));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEW_FARRAY2, DIM_TYPE* DIM1     , DIM_TYPE* DIM2     )
+  (DATA_TYPE*  data_temp = NULL  , DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements")
+  (DATA_TYPE** ARGOUTVIEW_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+{
+  npy_intp dims[2] = { *$2, *$3 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_FARRAY2)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1     , DIM_TYPE* DIM2     , DATA_TYPE** ARGOUTVIEW_FARRAY2)
+  (DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp, DATA_TYPE*  data_temp = NULL  )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEW_FARRAY2)
+{
+  npy_intp dims[2] = { *$1, *$2 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$3));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEW_ARRAY3, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    )
+  (DATA_TYPE* data_temp = NULL  , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DATA_TYPE** ARGOUTVIEW_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+{
+  npy_intp dims[3] = { *$2, *$3, *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
+                      DATA_TYPE** ARGOUTVIEW_ARRAY3)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEW_ARRAY3)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DATA_TYPE* data_temp = NULL)
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEW_ARRAY3)
+{
+  npy_intp dims[3] = { *$1, *$2, *$3 };
+  PyObject* obj = PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$4));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEW_FARRAY3, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    )
+  (DATA_TYPE* data_temp = NULL   , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements")
+  (DATA_TYPE** ARGOUTVIEW_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+{
+  npy_intp dims[3] = { *$2, *$3, *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
+                      DATA_TYPE** ARGOUTVIEW_FARRAY3)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DATA_TYPE** ARGOUTVIEW_FARRAY3)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DATA_TYPE* data_temp = NULL   )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEW_FARRAY3)
+{
+  npy_intp dims[3] = { *$1, *$2, *$3 };
+  PyObject* obj = PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$4));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEW_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEW_ARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
+  (DATA_TYPE* data_temp = NULL  , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+  $5 = &dim4_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DATA_TYPE** ARGOUTVIEW_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+{
+  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
+                      DATA_TYPE** ARGOUTVIEW_ARRAY4)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEW_ARRAY4)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL  )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &dim4_temp;
+  $5 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEW_ARRAY4)
+{
+  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEW_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEW_FARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
+  (DATA_TYPE* data_temp = NULL   , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+  $5 = &dim4_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements")
+  (DATA_TYPE** ARGOUTVIEW_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+{
+  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
+                      DATA_TYPE** ARGOUTVIEW_FARRAY4)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEW_FARRAY4)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL   )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &dim4_temp;
+  $5 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEW_FARRAY4)
+{
+  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/*************************************/
+/* Managed Argoutview Array Typemaps */
+/*************************************/
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY1, DIM_TYPE* DIM1)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY1, DIM_TYPE* DIM1    )
+  (DATA_TYPE*  data_temp = NULL  , DIM_TYPE  dim_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY1, DIM_TYPE* DIM1)
+{
+  npy_intp dims[1] = { *$2 };
+  PyObject* obj = PyArray_SimpleNewFromData(1, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEWM_ARRAY1)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DATA_TYPE** ARGOUTVIEWM_ARRAY1)
+  (DIM_TYPE  dim_temp, DATA_TYPE*  data_temp = NULL  )
+{
+  $1 = &dim_temp;
+  $2 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DIM_TYPE* DIM1, DATA_TYPE** ARGOUTVIEWM_ARRAY1)
+{
+  npy_intp dims[1] = { *$1 };
+  PyObject* obj = PyArray_SimpleNewFromData(1, dims, DATA_TYPECODE, (void*)(*$2));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$2), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY2, DIM_TYPE* DIM1     , DIM_TYPE* DIM2     )
+  (DATA_TYPE*  data_temp = NULL  , DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+{
+  npy_intp dims[2] = { *$2, *$3 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_ARRAY2)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1     , DIM_TYPE* DIM2     , DATA_TYPE** ARGOUTVIEWM_ARRAY2)
+  (DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp, DATA_TYPE*  data_temp = NULL  )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_ARRAY2)
+{
+  npy_intp dims[2] = { *$1, *$2 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$3));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$3), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEWM_FARRAY2, DIM_TYPE* DIM1     , DIM_TYPE* DIM2     )
+  (DATA_TYPE*  data_temp = NULL   , DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
+  (DATA_TYPE** ARGOUTVIEWM_FARRAY2, DIM_TYPE* DIM1, DIM_TYPE* DIM2)
+{
+  npy_intp dims[2] = { *$2, *$3 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_FARRAY2)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1     , DIM_TYPE* DIM2     , DATA_TYPE** ARGOUTVIEWM_FARRAY2)
+  (DIM_TYPE  dim1_temp, DIM_TYPE  dim2_temp, DATA_TYPE*  data_temp = NULL   )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DATA_TYPE** ARGOUTVIEWM_FARRAY2)
+{
+  npy_intp dims[2] = { *$1, *$2 };
+  PyObject* obj = PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE, (void*)(*$3));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$3), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY3, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    )
+  (DATA_TYPE* data_temp = NULL   , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+{
+  npy_intp dims[3] = { *$2, *$3, *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
+                      DATA_TYPE** ARGOUTVIEWM_ARRAY3)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DATA_TYPE** ARGOUTVIEWM_ARRAY3)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DATA_TYPE* data_temp = NULL   )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEWM_ARRAY3)
+{
+  npy_intp dims[3] = { *$1, *$2, *$3 };
+  PyObject* obj= PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$4));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$4), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEWM_FARRAY3, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    )
+  (DATA_TYPE* data_temp = NULL    , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
+  (DATA_TYPE** ARGOUTVIEWM_FARRAY3, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3)
+{
+  npy_intp dims[3] = { *$2, *$3, *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3,
+                      DATA_TYPE** ARGOUTVIEWM_FARRAY3)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DATA_TYPE** ARGOUTVIEWM_FARRAY3)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DATA_TYPE* data_temp = NULL    )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DATA_TYPE** ARGOUTVIEWM_FARRAY3)
+{
+  npy_intp dims[3] = { *$1, *$2, *$3 };
+  PyObject* obj = PyArray_SimpleNewFromData(3, dims, DATA_TYPECODE, (void*)(*$4));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$4), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
+  (DATA_TYPE* data_temp = NULL   , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+  $5 = &dim4_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DATA_TYPE** ARGOUTVIEWM_ARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+{
+  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
+                      DATA_TYPE** ARGOUTVIEWM_ARRAY4)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEWM_ARRAY4)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL   )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &dim4_temp;
+  $5 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Utilities")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_ARRAY4)
+{
+  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$5), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2,
+                      DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+ */
+%typemap(in,numinputs=0)
+  (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    )
+  (DATA_TYPE* data_temp = NULL    , DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp)
+{
+  $1 = &data_temp;
+  $2 = &dim1_temp;
+  $3 = &dim2_temp;
+  $4 = &dim3_temp;
+  $5 = &dim4_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
+  (DATA_TYPE** ARGOUTVIEWM_FARRAY4, DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4)
+{
+  npy_intp dims[4] = { *$2, *$3, *$4 , *$5 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$1));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$1), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/* Typemap suite for (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4,
+                      DATA_TYPE** ARGOUTVIEWM_FARRAY4)
+ */
+%typemap(in,numinputs=0)
+  (DIM_TYPE* DIM1    , DIM_TYPE* DIM2    , DIM_TYPE* DIM3    , DIM_TYPE* DIM4    , DATA_TYPE** ARGOUTVIEWM_FARRAY4)
+  (DIM_TYPE dim1_temp, DIM_TYPE dim2_temp, DIM_TYPE dim3_temp, DIM_TYPE dim4_temp, DATA_TYPE* data_temp = NULL    )
+{
+  $1 = &dim1_temp;
+  $2 = &dim2_temp;
+  $3 = &dim3_temp;
+  $4 = &dim4_temp;
+  $5 = &data_temp;
+}
+%typemap(argout,
+         fragment="NumPy_Backward_Compatibility,NumPy_Array_Requirements,NumPy_Utilities")
+  (DIM_TYPE* DIM1, DIM_TYPE* DIM2, DIM_TYPE* DIM3, DIM_TYPE* DIM4, DATA_TYPE** ARGOUTVIEWM_FARRAY4)
+{
+  npy_intp dims[4] = { *$1, *$2, *$3 , *$4 };
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, DATA_TYPECODE, (void*)(*$5));
+  PyArrayObject* array = (PyArrayObject*) obj;
+
+  if (!array || !require_fortran(array)) SWIG_fail;
+
+PyObject* cap = PyCapsule_New((void*)(*$5), SWIGPY_CAPSULE_NAME, free_cap);
+
+%#if NPY_API_VERSION < NPY_1_7_API_VERSION
+  PyArray_BASE(array) = cap;
+%#else
+  PyArray_SetBaseObject(array,cap);
+%#endif
+
+  $result = SWIG_Python_AppendOutput($result,obj);
+}
+
+/**************************************/
+/* In-Place Array Typemap - flattened */
+/**************************************/
+
+/* Typemap suite for (DATA_TYPE* INPLACE_ARRAY_FLAT, DIM_TYPE DIM_FLAT)
+ */
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros")
+  (DATA_TYPE* INPLACE_ARRAY_FLAT, DIM_TYPE DIM_FLAT)
+{
+  $1 = is_array($input) && PyArray_EquivTypenums(array_type($input),
+                                                 DATA_TYPECODE);
+}
+%typemap(in,
+         fragment="NumPy_Fragments")
+  (DATA_TYPE* INPLACE_ARRAY_FLAT, DIM_TYPE DIM_FLAT)
+  (PyArrayObject* array=NULL, int i=1)
+{
+  array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+  if (!array || !require_c_or_f_contiguous(array)
+      || !require_native(array)) SWIG_fail;
+  $1 = (DATA_TYPE*) array_data(array);
+  $2 = 1;
+  for (i=0; i < array_numdims(array); ++i) $2 *= array_size(array,i);
+}
+
+%enddef    /* %numpy_typemaps() macro */
+/* *************************************************************** */
+
+/* Concrete instances of the %numpy_typemaps() macro: Each invocation
+ * below applies all of the typemaps above to the specified data type.
+ */
+%numpy_typemaps(signed char       , NPY_BYTE     , int)
+%numpy_typemaps(unsigned char     , NPY_UBYTE    , int)
+%numpy_typemaps(short             , NPY_SHORT    , int)
+%numpy_typemaps(unsigned short    , NPY_USHORT   , int)
+%numpy_typemaps(int               , NPY_INT      , int)
+%numpy_typemaps(unsigned int      , NPY_UINT     , int)
+%numpy_typemaps(long              , NPY_LONG     , int)
+%numpy_typemaps(unsigned long     , NPY_ULONG    , int)
+%numpy_typemaps(long long         , NPY_LONGLONG , int)
+%numpy_typemaps(unsigned long long, NPY_ULONGLONG, int)
+%numpy_typemaps(float             , NPY_FLOAT    , int)
+%numpy_typemaps(double            , NPY_DOUBLE   , int)
+%numpy_typemaps(int8_t            , NPY_INT8     , int)
+%numpy_typemaps(int16_t           , NPY_INT16    , int)
+%numpy_typemaps(int32_t           , NPY_INT32    , int)
+%numpy_typemaps(int64_t           , NPY_INT64    , int)
+%numpy_typemaps(uint8_t           , NPY_UINT8    , int)
+%numpy_typemaps(uint16_t          , NPY_UINT16   , int)
+%numpy_typemaps(uint32_t          , NPY_UINT32   , int)
+%numpy_typemaps(uint64_t          , NPY_UINT64   , int)
+
+
+/* ***************************************************************
+ * The follow macro expansion does not work, because C++ bool is 4
+ * bytes and NPY_BOOL is 1 byte
+ *
+ *    %numpy_typemaps(bool, NPY_BOOL, int)
+ */
+
+/* ***************************************************************
+ * On my Mac, I get the following warning for this macro expansion:
+ * 'swig/python detected a memory leak of type 'long double *', no destructor found.'
+ *
+ *    %numpy_typemaps(long double, NPY_LONGDOUBLE, int)
+ */
+
+#ifdef __cplusplus
+
+%include <std_complex.i>
+
+%numpy_typemaps(std::complex<float>,  NPY_CFLOAT , int)
+%numpy_typemaps(std::complex<double>, NPY_CDOUBLE, int)
+
+#endif
+
+#endif /* SWIGPYTHON */

--- a/tools/py_typemaps.i
+++ b/tools/py_typemaps.i
@@ -1,0 +1,561 @@
+//#ifdef HAVE_PYTHON
+%{
+#ifndef SWIG_FILE_WITH_INIT
+#  define NO_IMPORT_ARRAY
+#endif
+#include <stdio.h>
+//#include "spams.h"
+#undef _POSIX_C_SOURCE
+extern "C" {
+#include <Python.h>
+#include <numpy/arrayobject.h>
+}
+#define check_array_int(a) (!is_array(a) || !require_contiguous(a) || !require_dimensions(a,1) || !require_native(a) || !PyArray_ISINTEGER(a))
+#define check_array(a,npy_type) (!is_array(a) || !require_contiguous(a) || !require_dimensions(a,1) || !require_native(a) || array_type(a)!=npy_type)
+%}
+
+//#endif
+%include "numpy.i"
+
+%typemap(throws) const char * %{
+  PyErr_SetString(PyExc_RuntimeError, $1);
+  SWIG_fail;
+%}
+
+%define %vector_typemaps(DATA_TYPE,DATA_TYPECODE)
+
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros") (Vector<DATA_TYPE> *INPLACE_VECTOR)
+{
+	$1 = is_array($input) && (array_numdims($input) == 1) && PyArray_EquivTypenums(array_type($input),DATA_TYPECODE);
+
+}
+%typemap(in,fragment="NumPy_Fragments") (Vector<DATA_TYPE> *INPLACE_VECTOR)
+	(PyArrayObject* array=NULL)
+{
+    array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+    if (!array || !require_dimensions(array,1) || !require_contiguous(array) || !require_native(array)) SWIG_fail;
+	 $1 = new Vector<DATA_TYPE> ((DATA_TYPE *)array_data(array),(int)array_size(array,0));
+}
+%typemap(out) (Vector<DATA_TYPE> *)
+{
+    npy_intp n = result->n();
+    npy_intp dims[1] = {n};
+    PyArrayObject * array = (PyArrayObject * )PyArray_SimpleNew(1, dims, DATA_TYPECODE);
+    DATA_TYPE *data = (DATA_TYPE *)array->data;
+    DATA_TYPE *idata = result->rawX();
+    memcpy(data,idata,n * sizeof(DATA_TYPE));
+    delete result;
+    $result = SWIG_Python_AppendOutput($result,(PyObject*)array);
+
+}
+%typemap(freearg)
+  (Vector<DATA_TYPE> *INPLACE_VECTOR)
+{
+	delete arg$argnum;
+}
+
+// ARGOUT
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY) (Vector<DATA_TYPE> **ARGOUT_VECTOR)
+{
+	$1 = 1;
+
+}
+
+%typemap(in,numinputs=0,fragment="NumPy_Fragments") (Vector<DATA_TYPE> **ARGOUT_VECTOR)
+(Vector<DATA_TYPE>  *data_temp)
+{
+	$1 = &data_temp;
+}
+
+%typemap(argout) (Vector<DATA_TYPE> **ARGOUT_VECTOR )
+{
+
+	  if(data_temp$argnum != NULL) {
+	    npy_intp n = data_temp$argnum->n();
+	    npy_intp dims[1] = {n};
+	    DATA_TYPE *data = data_temp$argnum->rawX();
+	    PyArrayObject * array = (PyArrayObject * )PyArray_SimpleNewFromData(1, dims, DATA_TYPECODE,(void*)data);
+	   if (!array) SWIG_fail;
+           $result = SWIG_Python_AppendOutput($result,(PyObject*)array);
+	  }
+}
+
+%enddef /* %vector_typemaps */
+
+%define map_matrix(DATA_TYPE,DATA_TYPECODE)
+	array = obj_to_array_no_conversion($input, DATA_TYPECODE);
+	/* !!!!!
+	WARNING! bug (?) : the variable name choosen above must not appear
+	in the string, otherwise swig will not correctly generate
+	final variable names (above name + number)
+	*/
+	/* we cannot use require_fortran, because it convert a numpy C array to a numpy
+	fortran array by just modifying the strides */
+	if (!array || !require_dimensions(array,2) || !array_is_fortran(array) || !require_native(array)) {
+	SWIG_Python_SetErrorMsg(PyExc_RuntimeError,"matrix arg $argnum must be a 2d DATA_TYPE Fortran Array"); SWIG_fail;
+	}
+	$1 = new Matrix<DATA_TYPE> ((DATA_TYPE *)array_data(array),(int)array_size(array,0),(int)array_size(array,1));
+
+%enddef /* map_matrix */
+
+%define %matrix_typemaps(DATA_TYPE,DATA_TYPECODE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros") (Matrix<DATA_TYPE> *INPLACE_MATRIX)
+{
+	$1 = is_array($input) && (array_numdims($input) == 2) && PyArray_EquivTypenums(array_type($input),DATA_TYPECODE);
+
+}
+%typemap(in,fragment="NumPy_Fragments") (Matrix<DATA_TYPE> *INPLACE_MATRIX)
+	(PyArrayObject* array=NULL)
+{
+	map_matrix(DATA_TYPE,DATA_TYPECODE)
+}
+%typemap(out) (Matrix<DATA_TYPE> *)
+{
+    npy_intp m = result->m();
+    npy_intp n = result->n();
+    npy_intp dims[2] = {m,n};
+
+    PyArrayObject * array = (PyArrayObject * )PyArray_SimpleNew(2, dims, DATA_TYPECODE);
+    DATA_TYPE *data = (DATA_TYPE *)array->data;
+    DATA_TYPE *idata = result->rawX();
+    memcpy(data,idata,m * n * sizeof(DATA_TYPE));
+    delete result;
+    if (! require_fortran(array)) {
+       SWIG_Python_SetErrorMsg(PyExc_RuntimeError,"Cannot make a fortran out matrix"); SWIG_fail;}
+    $result = SWIG_Python_AppendOutput($result,(PyObject*)array);
+
+}
+%typemap(freearg)
+  (Matrix<DATA_TYPE> *INPLACE_MATRIX)
+{
+	delete arg$argnum;
+}
+// ARGOUT
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY) (Matrix<DATA_TYPE> **ARGOUT_MATRIX)
+{
+	$1 = 1;
+
+}
+
+%typemap(in,numinputs=0,fragment="NumPy_Fragments") (Matrix<DATA_TYPE> **ARGOUT_MATRIX)
+(Matrix<DATA_TYPE>  *data_temp)
+{
+	$1 = &data_temp;
+}
+
+%typemap(argout) (Matrix<DATA_TYPE> **ARGOUT_MATRIX )
+{
+
+	  if(data_temp$argnum != NULL) {
+	    npy_intp m = data_temp$argnum->m();
+	    npy_intp n = data_temp$argnum->n();
+	    npy_intp dims[2] = {m,n};
+	    DATA_TYPE *data = data_temp$argnum->rawX();
+	    PyArrayObject * array = (PyArrayObject * )PyArray_SimpleNewFromData(2, dims, DATA_TYPECODE,(void*)data);
+	   if (!array) SWIG_fail;
+	   if (! require_fortran(array)) {
+       	      SWIG_Python_SetErrorMsg(PyExc_RuntimeError,"Cannot make a fortran argout matrix"); SWIG_fail;}
+
+           $result = SWIG_Python_AppendOutput($result,(PyObject*)array);
+        }
+}
+
+
+%enddef /* %matrix_typemaps */
+
+%fragment("DSp_Check","header")
+{
+   const int check_sparse(PyObject* input) {
+    return (PyObject_HasAttrString(input, "indptr") &&
+        PyObject_HasAttrString(input, "indices") &&
+        PyObject_HasAttrString(input, "data") &&
+        PyObject_HasAttrString(input, "shape")
+        ) ? 1 : 0;
+  }
+  const int check_matrix(PyObject* input,int data_typecode) {
+   return (is_array(input) && (array_numdims(input) == 2) && PyArray_EquivTypenums(array_type(input),data_typecode));
+  }
+}
+
+%define map_sparse(DATA_TYPE,DATA_TYPECODE)
+        sparray = $input;
+	if ( !( PyObject_HasAttrString(sparray, "indptr") &&
+            PyObject_HasAttrString(sparray, "indices") &&
+            PyObject_HasAttrString(sparray, "data") &&
+		PyObject_HasAttrString(sparray, "shape"))) {
+	  SWIG_Python_SetErrorMsg(PyExc_RuntimeError,"arg $argnum : not a column compressed sparse matrix");
+	  return NULL;
+	}
+
+        /* fetch sparse attributes */
+        PyArrayObject* indptr = (PyArrayObject *) PyObject_GetAttrString(sparray, "indptr");
+        PyArrayObject* indices = (PyArrayObject *) PyObject_GetAttrString(sparray, "indices");
+        PyArrayObject* data = (PyArrayObject *) PyObject_GetAttrString(sparray, "data");
+        PyObject* shape = PyObject_GetAttrString(sparray, "shape");
+
+        /* check that types are OK */
+	if (check_array_int(indptr))
+        {
+            PyErr_SetString(PyExc_TypeError,"spmatrix arg$argnum: indptr array should be 1d int's");
+            return NULL;
+        }
+
+	  if check_array_int(indices)
+        {
+            PyErr_SetString(PyExc_TypeError,"spmatrix arg$argnum: indices array should be 1d int's");
+            return NULL;
+        }
+
+	    if check_array(data, DATA_TYPECODE)
+        {
+            PyErr_SetString(PyExc_TypeError,"spmatrix arg$argnum: data array should be 1d and match datatype");
+            return NULL;
+        }
+
+        if (!PyTuple_Check(shape))
+        {
+            PyErr_SetString(PyExc_TypeError,"shape should be a tuple");
+            return NULL;
+        }
+
+        /* get array dimensions */
+        int32_t m =PyInt_AsLong(PyTuple_GetItem(shape, 0));
+        int32_t n =PyInt_AsLong(PyTuple_GetItem(shape, 1));
+
+
+	int *pB = (int *)array_data(indptr);
+	int *pE = pB + 1;
+	int nzmax = (int)array_size(data,0);
+	Py_DECREF(indptr);
+        Py_DECREF(indices);
+        Py_DECREF(data);
+        Py_DECREF(shape);
+
+
+	$1 = new SpMatrix<DATA_TYPE> ((DATA_TYPE *)array_data(data),(int *)array_data(indices),pB,pE,m,n,nzmax);
+%enddef /* map_sparse */
+
+%define %spmatrix_typemaps(DATA_TYPE,DATA_TYPECODE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros",fragment="DSp_Check") (SpMatrix<DATA_TYPE> *INPLACE_SPMATRIX)
+{
+	$1 = check_sparse($input);
+/*
+	$1 = ( PyObject_HasAttrString($input, "indptr") &&
+        PyObject_HasAttrString($input, "indices") &&
+        PyObject_HasAttrString($input, "data") &&
+        PyObject_HasAttrString($input, "shape")
+        ) ? 1 : 0;
+*/
+}
+%typemap(in,fragment="NumPy_Fragments") (SpMatrix<DATA_TYPE> *INPLACE_SPMATRIX)
+	(PyObject* sparray=NULL)
+{
+	    /* a column compressed storage sparse matrix in python scipy
+       looks like this
+
+       A = csc_matrix( ... )
+       A.indptr # pointer array
+       A.indices # indices array
+       A.data # nonzero values array
+       A.shape # size of matrix
+
+       >>> type(A.indptr)
+       <type 'numpy.ndarray'> #int32
+       >>> type(A.indices)
+       <type 'numpy.ndarray'> #int32
+       >>> type(A.data)
+       <type 'numpy.ndarray'>
+       >>> type(A.shape)
+       <type 'tuple'>
+     */
+     map_sparse(DATA_TYPE,DATA_TYPECODE)
+
+}
+%typemap(out) (SpMatrix<DATA_TYPE> *)
+{
+    npy_intp m = result->m();
+    npy_intp n = result->n();
+    npy_intp nzmax = result->nzmax();
+    npy_intp dims[2] = {m,n};
+    dims[0] = n + 1;
+    PyArrayObject *indptr = (PyArrayObject * )PyArray_SimpleNew(1,dims, NPY_INT);
+    dims[0] = nzmax;
+    PyArrayObject *indices = (PyArrayObject * )PyArray_SimpleNew(1,dims, NPY_INT);
+    PyArrayObject *vdata = (PyArrayObject * )PyArray_SimpleNew(1,dims, DATA_TYPECODE);
+    int i;
+    DATA_TYPE *xdata = result->v();
+    DATA_TYPE *data = (DATA_TYPE *)array_data(vdata);
+    memcpy(data,xdata,nzmax * sizeof(DATA_TYPE));
+    npy_int *pi = (npy_int *)array_data(indices);
+    int *r = result->r();
+    int *pB = result->pB();
+    if(sizeof(npy_int) == sizeof(int)) {
+       memcpy(pi,r,nzmax * sizeof(int));
+       pi = (npy_int *)array_data(indptr);
+       memcpy(pi,pB,(n + 1) * sizeof(int));
+    } else {
+      for(i = 0;i< nzmax;i++)
+    	  *(pi+i) = (npy_int) *(r+i);
+      pi = (npy_int *)array_data(indptr);
+      for(i = 0;i< n + 1;i++)
+    	  *(pi+i) = (npy_int) *(pB+i);
+    }
+    PyObject* tuple = PyTuple_New(4);
+    PyObject* shape = PyTuple_New(2);
+    PyTuple_SetItem(shape, 0,  PyInt_FromLong((long)m));
+    PyTuple_SetItem(shape, 1,  PyInt_FromLong((long)n));
+    PyTuple_SetItem(tuple,0, (PyObject* )indptr);
+    PyTuple_SetItem(tuple,1,(PyObject* )indices);
+    PyTuple_SetItem(tuple,2,(PyObject* )vdata);
+    PyTuple_SetItem(tuple,3,shape);
+    delete result;
+    $result = SWIG_Python_AppendOutput($result,tuple);
+}
+%typemap(freearg)
+  (SpMatrix<DATA_TYPE> *INPLACE_SPMATRIX)
+{
+	delete arg$argnum;
+}
+// ARGOUT
+%typemap(in,numinputs=0) (SpMatrix<DATA_TYPE> **ARGOUT_SPMATRIX )
+(SpMatrix<DATA_TYPE> *data_temp)
+{
+	$1 = &data_temp;
+}
+%typemap(argout) (SpMatrix<DATA_TYPE> **ARGOUT_SPMATRIX )
+{
+  if(data_temp$argnum != NULL) {
+    npy_intp m = data_temp$argnum->m();
+    npy_intp n = data_temp$argnum->n();
+    npy_intp nzmax = data_temp$argnum->nzmax();
+    npy_intp dims[2] = {m,n};
+    dims[0] = n + 1;
+    PyArrayObject *indptr = (PyArrayObject * )PyArray_SimpleNew(1,dims, NPY_INT);
+    dims[0] = nzmax;
+    PyArrayObject *indices = (PyArrayObject * )PyArray_SimpleNew(1,dims, NPY_INT);
+    PyArrayObject *vdata = (PyArrayObject * )PyArray_SimpleNew(1,dims, DATA_TYPECODE);
+    if (! indptr || !indices || !vdata) SWIG_fail;
+    int i;
+    DATA_TYPE *xdata = data_temp$argnum->v();
+    DATA_TYPE *data = (DATA_TYPE *)array_data(vdata);
+    memcpy(data,xdata,nzmax * sizeof(DATA_TYPE));
+    npy_int *pi = (npy_int *)array_data(indices);
+    int *r = data_temp$argnum->r();
+    int *pB = data_temp$argnum->pB();
+    if(sizeof(npy_int) == sizeof(int)) {
+       memcpy(pi,r,nzmax * sizeof(int));
+       pi = (npy_int *)array_data(indptr);
+       memcpy(pi,pB,(n + 1) * sizeof(int));
+    } else {
+      for(i = 0;i< nzmax;i++)
+    	  *(pi+i) = (npy_int) *(r+i);
+      pi = (npy_int *)array_data(indptr);
+      for(i = 0;i< n + 1;i++)
+    	  *(pi+i) = (npy_int) *(pB+i);
+    }
+    PyObject* tuple = PyTuple_New(4);
+    PyObject* shape = PyTuple_New(2);
+    PyTuple_SetItem(shape, 0,  PyInt_FromLong((long)m));
+    PyTuple_SetItem(shape, 1,  PyInt_FromLong((long)n));
+    PyTuple_SetItem(tuple,0, (PyObject* )indptr);
+    PyTuple_SetItem(tuple,1,(PyObject* )indices);
+    PyTuple_SetItem(tuple,2,(PyObject* )vdata);
+    PyTuple_SetItem(tuple,3,shape);
+    $result = SWIG_Python_AppendOutput($result,tuple);
+  }
+}
+%enddef /* %spmatrix_typemaps */
+
+%define %dspmatrix_typemaps(DATA_TYPE,DATA_TYPECODE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros",fragment="DSp_Check") (AbstractMatrixB<DATA_TYPE> *INPLACE_DSPMATRIX)
+{
+	if( PyObject_HasAttrString($input, "indptr"))
+	    $1 = check_sparse($input);
+	else
+	    $1 = check_matrix($input,DATA_TYPECODE);
+#if 0
+	$1 = ( PyObject_HasAttrString($input, "indptr") &&
+        PyObject_HasAttrString($input, "indices") &&
+        PyObject_HasAttrString($input, "data") &&
+        PyObject_HasAttrString($input, "shape")
+        ) ? 1 : 0;
+#endif
+}
+%typemap(in,fragment="NumPy_Fragments") (AbstractMatrixB<DATA_TYPE> *INPLACE_DSPMATRIX)
+
+{
+	    /* a column compressed storage sparse matrix in python scipy
+       looks like this
+
+       A = csc_matrix( ... )
+       A.indptr # pointer array
+       A.indices # indices array
+       A.data # nonzero values array
+       A.shape # size of matrix
+
+       >>> type(A.indptr)
+       <type 'numpy.ndarray'> #int32
+       >>> type(A.indices)
+       <type 'numpy.ndarray'> #int32
+       >>> type(A.data)
+       <type 'numpy.ndarray'>
+       >>> type(A.shape)
+       <type 'tuple'>
+     */
+     if ( PyObject_HasAttrString($input, "indptr")) {
+       	PyObject* sparray =$input;
+	map_sparse(DATA_TYPE,DATA_TYPECODE)
+     } else {
+       	PyArrayObject* array = NULL;
+        map_matrix(DATA_TYPE,DATA_TYPECODE)
+     }
+}
+%typemap(freearg)
+  (AbstractMatrixB<DATA_TYPE> *INPLACE_DSPMATRIX)
+{
+	delete arg$argnum;
+}
+
+%enddef /* %dspmatrix_typemaps */
+
+%define %datamatrix_typemaps(DATA_TYPE,DATA_TYPECODE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros",fragment="DSp_Check") (Data<DATA_TYPE> *INPLACE_DATAMATRIX)
+{
+	if( PyObject_HasAttrString($input, "indptr"))
+	    $1 = check_sparse($input);
+	else
+	    $1 = check_matrix($input,DATA_TYPECODE);
+}
+%typemap(in,fragment="NumPy_Fragments") (Data<DATA_TYPE> *INPLACE_DATAMATRIX)
+
+{
+     if ( PyObject_HasAttrString($input, "indptr")) {
+       	PyObject* sparray =$input;
+	map_sparse(DATA_TYPE,DATA_TYPECODE)
+     } else {
+       	PyArrayObject* array = NULL;
+        map_matrix(DATA_TYPE,DATA_TYPECODE)
+     }
+}
+%typemap(freearg)
+  (Data<DATA_TYPE> *INPLACE_DATAMATRIX)
+{
+	delete arg$argnum;
+}
+
+%enddef /* %datamatrix_typemaps */
+
+%define %node_typemaps(DATA_TYPE,DATA_TYPECODE)
+%typecheck(SWIG_TYPECHECK_DOUBLE_ARRAY,
+           fragment="NumPy_Macros") (std::vector<StructNodeElem<DATA_TYPE> *> *TREE)
+{
+	$1 = PyList_Check($input);
+
+}
+
+%typemap(in) (std::vector<StructNodeElem<DATA_TYPE> *> *TREE)
+{
+  PyObject* pytree = $input;
+  if(!PyList_Check(pytree)) {
+    SWIG_Python_SetErrorMsg(PyExc_RuntimeError,"arg $argnum must be a list");SWIG_fail;
+  }
+  $1 = new std::vector<StructNodeElem<DATA_TYPE> *>;
+  for(Py_ssize_t i = 0;i < PyList_Size(pytree);i++) {
+    PyObject* pynode = PyList_GetItem(pytree,i);
+    if(! PyTuple_Check(pynode) || (PyTuple_Size(pynode) != 4)) {
+      SWIG_Python_SetErrorMsg(PyExc_RuntimeError,"List elements of arg $argnum must be tuples of size 4");SWIG_fail;
+    }
+    long inode = PyInt_AsLong(PyTuple_GetItem(pynode,(Py_ssize_t)0));
+    DATA_TYPE w = PyFloat_AsDouble(PyTuple_GetItem(pynode,(Py_ssize_t)1));
+    std::vector<int> *vars = new std::vector<int>;
+    std::vector<int> *children = new std::vector<int>;
+    PyObject* pyvars = PyTuple_GetItem(pynode,(Py_ssize_t)2);
+    PyObject* pychildren = PyTuple_GetItem(pynode,(Py_ssize_t)3);
+    for(Py_ssize_t j = 0;j < PyList_Size(pyvars);j++)
+      vars->push_back(static_cast<int>(PyInt_AsLong(PyList_GetItem(pyvars,j))));
+    for(Py_ssize_t j = 0;j < PyList_Size(pychildren);j++)
+      children->push_back(static_cast<int>(PyInt_AsLong(PyList_GetItem(pychildren,j))));
+    StructNodeElem<DATA_TYPE> *node = new StructNodeElem<DATA_TYPE>(inode,w,vars,children);
+    $1->push_back(node);
+  }
+
+}
+
+%typemap(out) (std::vector<StructNodeElem<DATA_TYPE> *> *)
+{
+  //int n = result->size();
+  PyObject* node_list = PyList_New(0);
+  for(std::vector<StructNodeElem<DATA_TYPE> *>::iterator it = result->begin();it != result->end();it++) {
+    PyObject* tuple = PyTuple_New(4);
+    StructNodeElem<DATA_TYPE> *node = *it;
+    int inode = node->node_num;
+    PyTuple_SetItem(tuple,0, PyInt_FromLong((long)inode));
+    PyTuple_SetItem(tuple,1, PyFloat_FromDouble(node->weight));
+    int k = node->vars->size();
+    PyObject *vars = PyList_New(0);
+    std::vector<int> *pvars = node->vars;
+    for(int i = 0;i < k;i++)
+      PyList_Append(vars,PyInt_FromLong((long)(*pvars)[i]));
+    PyTuple_SetItem(tuple,2, (PyObject* )vars);
+    k = node->children->size();
+    pvars = node->children;
+    PyObject *children = PyList_New(0);
+    for(int i = 0;i < k;i++)
+      PyList_Append(children,PyInt_FromLong((long)(*pvars)[i]));
+
+    PyTuple_SetItem(tuple,3,(PyObject* )children );
+    PyList_Append(node_list,tuple);
+  }
+  del_gstruct(result);
+  $result = SWIG_Python_AppendOutput($result,node_list);
+}
+
+%typemap(freearg)
+  (std::vector<StructNodeElem<DATA_TYPE> *> *TREE)
+{
+  del_gstruct(arg$argnum);
+}
+%enddef /* %node_typemaps */
+
+%vector_typemaps(float, NPY_FLOAT)
+%vector_typemaps(double, NPY_DOUBLE)
+%vector_typemaps(int, NPY_INT)
+
+%matrix_typemaps(float, NPY_FLOAT)
+%matrix_typemaps(double, NPY_DOUBLE)
+%matrix_typemaps(bool, NPY_BOOL)
+
+%spmatrix_typemaps(float, NPY_FLOAT)
+%spmatrix_typemaps(double, NPY_DOUBLE)
+%spmatrix_typemaps(bool, NPY_BOOL)
+
+%dspmatrix_typemaps(float, NPY_FLOAT)
+%dspmatrix_typemaps(double, NPY_DOUBLE)
+
+%datamatrix_typemaps(float, NPY_FLOAT)
+%datamatrix_typemaps(double, NPY_DOUBLE)
+
+%node_typemaps(float, NPY_FLOAT)
+%node_typemaps(double, NPY_DOUBLE)
+
+// In case of multiple instantiation :
+// template with same name : OK in spite of warning
+// But the args are checked to choose between implementations
+// special type need a typecheck typemap
+#ifndef WINDOWS
+       %define INSTANTIATE_DATA( f_name )
+       %feature("autodoc","1") _ ## f_name;
+       %template(f_name) _ ## f_name<double>;
+       %template(f_name) _ ## f_name<float>;
+       %enddef
+#else
+	%define INSTANTIATE_DATA( f_name )
+	%feature("autodoc","1") _ ## f_name;
+	%template(f_name) _ ## f_name<double>;
+	%enddef
+#endif

--- a/tools/pyfragments.swg
+++ b/tools/pyfragments.swg
@@ -1,0 +1,110 @@
+/*-*- C -*-*/
+
+/**********************************************************************/
+
+/* For numpy versions prior to 1.0, the names of certain data types
+ * are different than in later versions.  This fragment provides macro
+ * substitutions that allow us to support old and new versions of
+ * numpy.
+ */
+
+/**********************************************************************/
+
+/* Override the SWIG_AsVal_frag(long) fragment so that it also checks
+ * for numpy scalar array types.  The code through the %#endif is
+ * essentially cut-and-paste from pyprimtype.swg
+ */
+
+%fragment(SWIG_AsVal_frag(long), "header",
+	  fragment="SWIG_CanCastAsInteger",
+          fragment="NumPy_Backward_Compatibility")
+{
+  SWIGINTERN int
+  SWIG_AsVal_dec(long)(PyObject * obj, long * val)
+  {
+    if (PyLong_Check(obj)) {
+      long v = PyLong_AsLong(obj);
+      if (v != -1 || !PyErr_Occurred()) {
+	if (val) *val = v;
+	return SWIG_OK;
+      } else {
+	PyErr_Clear();
+      }
+    }
+%#ifdef SWIG_PYTHON_CAST_MODE
+    {
+      int dispatch = 0;
+      long v = PyLong_AsLong(obj);
+      if (v != -1 || !PyErr_Occurred()) {
+	if (val) *val = v;
+	return SWIG_AddCast(SWIG_OK);
+      } else {
+	PyErr_Clear();
+      }
+      if (!dispatch) {
+	double d;
+	int res = SWIG_AddCast(SWIG_AsVal(double)(obj,&d));
+	if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
+	  if (val) *val = (long)(d);
+	  return res;
+	}
+      }
+    }
+%#endif
+    if (!PyArray_IsScalar(obj,Integer)) return SWIG_TypeError;
+    PyArray_Descr * longDescr = PyArray_DescrFromType(NPY_LONG);
+    PyArray_CastScalarToCtype(obj, (void*)val, longDescr);
+    Py_DECREF(longDescr);
+    return SWIG_OK;
+  }
+}
+
+
+/* Override the SWIG_AsVal_frag(unsigned long) fragment so that it
+ * also checks for numpy scalar array types.  The code through the
+ * %#endif is essentially cut-and-paste from pyprimtype.swg
+ */
+
+%fragment(SWIG_AsVal_frag(unsigned long),"header",
+	  fragment="SWIG_CanCastAsInteger",
+          fragment="NumPy_Backward_Compatibility")
+{
+  SWIGINTERN int
+  SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
+  {
+    if (PyLong_Check(obj)) {
+      unsigned long v = PyLong_AsUnsignedLong(obj);
+      if (!PyErr_Occurred()) {
+	if (val) *val = v;
+	return SWIG_OK;
+      } else {
+	PyErr_Clear();
+      }
+    }
+%#ifdef SWIG_PYTHON_CAST_MODE
+    {
+      int dispatch = 0;
+      unsigned long v = PyLong_AsUnsignedLong(obj);
+      if (!PyErr_Occurred()) {
+	if (val) *val = v;
+	return SWIG_AddCast(SWIG_OK);
+      } else {
+	PyErr_Clear();
+      }
+      if (!dispatch) {
+	double d;
+	int res = SWIG_AddCast(SWIG_AsVal(double)(obj,&d));
+	if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, 0, ULONG_MAX)) {
+	  if (val) *val = (unsigned long)(d);
+	  return res;
+	}
+      }
+    }
+%#endif
+    if (!PyArray_IsScalar(obj,Integer)) return SWIG_TypeError;
+    PyArray_Descr * ulongDescr = PyArray_DescrFromType(NPY_ULONG);
+    PyArray_CastScalarToCtype(obj, (void*)val, ulongDescr);
+    Py_DECREF(ulongDescr);
+    return SWIG_OK;
+  }
+}

--- a/tools/run_swig.sh
+++ b/tools/run_swig.sh
@@ -1,0 +1,1 @@
+swig -c++ -python -o spams_wrap/spams_wrap.cpp -O -builtin -dirvtable -threads -Ispams_wrap tools/spams.i

--- a/tools/run_swig.sh~
+++ b/tools/run_swig.sh~
@@ -1,0 +1,2 @@
+cd ../spams_wrap
+swig -c++ -python -o spams_wrap.cpp -O -builtin -dirvtable -threads tools/spams.i

--- a/tools/spams.i
+++ b/tools/spams.i
@@ -1,0 +1,220 @@
+%define DOCSTRING
+"This module gives access to some functions of the spams C++ library.
+The functions defined here should not be called directly.
+Use of spams functions should only be done through module spams."
+%enddef
+
+#ifdef SWIGPYTHON
+%module(docstring=DOCSTRING) spams_wrap
+#endif
+#ifdef SWIGR
+%module spams
+#endif
+
+%{
+#define SWIG_FILE_WITH_INIT
+
+#include "spams.h"
+#include "spams/prox/groups-graph.h"
+
+#ifdef DEBUG
+#include "spams-tst.h"
+#endif
+%}
+
+%define argout_vectors(ctype)
+	Vector<ctype> **omiter,
+	Vector<ctype> **peta_g,
+	Vector<ctype> **pown_variables,
+	Vector<ctype> **pN_own_variables
+%enddef
+
+/*
+   Following macros define which typemap must be applied to arguments of C++ functions are converted.
+   args of type inplace_* may containt input data or are ready (allocated)
+    to receive output data. Typemaps of type 'in' are applied to them
+    before function call.
+   args of type argout_* are used when multiple return values are needed.
+    they are of type **; their storage is allocated on return of the C++ function.
+     Typemaps of type 'in' are applied to them  before function call,
+     and typemaps of type 'argout' are applied to them afeter the call.
+  Note : typemaps of type ('out') are applied to return values of C++ functions.
+*****
+
+*/
+// list of arguments of type INPLACE_MATRIX
+%define inplace_bool_matrices
+	Matrix<bool> *B
+%enddef
+%define inplace_bool_spmatrices
+    SpMatrix<bool> *groups,
+    SpMatrix<bool> *groups_var
+%enddef
+
+%define inplace_matrices(ctype)
+     Matrix<ctype> *A,
+     Matrix<ctype> *B,
+     Matrix<ctype> *D,
+     Matrix<ctype> *D1,
+     Matrix<ctype> *Q,
+     Matrix<ctype> *q,
+     Matrix<ctype> *U,
+     Matrix<ctype> *V,
+     Matrix<ctype> *X,
+     Matrix<ctype> *m_A,
+     Matrix<ctype> *m_B,
+     Matrix<ctype> *XAt,
+     Matrix<ctype> *Y,
+     Matrix<ctype> *XY,
+     Matrix<ctype> *AAt,
+     Matrix<ctype> *alpha0,
+     Matrix<ctype> *alpha,
+     Matrix<ctype> *W,
+     Matrix<ctype> *Z0,
+     Matrix<ctype> *Z
+%enddef
+%define argout_matrices(ctype)
+     Matrix<ctype> **path,
+     Matrix<ctype> **omA,
+     Matrix<ctype> **omB
+%enddef
+%define inplace_vectors(ctype)
+    Vector<ctype> *v,
+    Vector<ctype> *b,
+    Vector<ctype> *x,
+    Vector<ctype> *xCurr,
+    Vector<ctype> *inner_weights,
+    Vector<ctype> *L,
+    Vector<ctype> *eps,
+    Vector<ctype> *Lambda,
+    Vector<ctype> *eta_g,
+    Vector<ctype> *own_variables,
+    Vector<ctype> *N_own_variables,
+    Vector<ctype> *groups
+%enddef
+%define inplace_spmatrices(ctype)
+    SpMatrix<ctype> *A,
+    SpMatrix<ctype> *alpha,
+    SpMatrix<ctype> *groups
+%enddef
+%define argout_spmatrices(ctype)
+    SpMatrix<ctype> **pgroups,
+    SpMatrix<ctype> **pgroups_var,
+    SpMatrix<ctype> **spA,
+    SpMatrix<ctype> **spB
+%enddef
+
+%define inplace_dspmatrices(ctype)
+    AbstractMatrixB<ctype> *D
+%enddef
+
+%define inplace_datamatrices(ctype)
+    Data<ctype> *X
+%enddef
+
+%define inplace_nodes(ctype)
+	std::vector<StructNodeElem<ctype> *> *gstruct
+%enddef
+
+#ifdef SWIGPYTHON
+%include "py_typemaps.i"
+%init %{
+    import_array();
+%}
+#endif
+
+#ifdef SWIGR
+%include "R_typemaps.i"
+#endif
+%include "spamstools.i"
+%include "exception.i"
+
+
+%include <spams.h>
+%include <spams/prox/groups-graph.h>
+
+//void im2col_sliding(Matrix<double>  *,Matrix<double>  *,int,int,bool);
+//std::vector<NodeElem *> *simpleGroupTree(int *degr, int n)throw(const char *);
+//std::vector<NodeElem *> *readGroupStruct(const char* file) throw(const char *);
+//std::vector<NodeElem *> *groupStructOfString(const char* data) throw(const char *);
+//Vector<double> * graphOfGroupStruct(std::vector<NodeElem *> *tree,SpMatrix<bool> **pgroups,SpMatrix<bool> **pgroups_var) throw(const char *);
+
+//int  treeOfGroupStruct(std::vector<StructNodeElem<double> *> *tree,int **pperm,int *pnb_vars,Vector<double> **peta_g,SpMatrix<bool> **pgroups,Vector<int> **pown_variables,Vector<int> **pN_own_variables) throw(const char *);
+
+#ifdef DEBUG
+%include <spams-tst.h>
+Matrix<double> *tst(Matrix<double> **,bool,AbstractMatrixB<double> *);
+//int xtst(Matrix<double> **,bool );
+SpMatrix<double> *xtst(Matrix<double> **,bool );
+Matrix<double> *ztst(Data<double> *,Matrix<double> **omA,Matrix<double> **,Vector<int> **,bool) throw(const char *);
+
+#endif
+
+// In case of multiple instantiation :
+// template with same name : OK in spite of warning
+// But the args are checked to choose between implementations
+// special type need a typecheck typemap
+#ifndef WINDOWS
+       %define INSTANTIATE_DATA( f_name )
+       %feature("autodoc","1") _ ## f_name;
+       %template(f_name) _ ## f_name<double>;
+       %template(f_name) _ ## f_name<float>;
+       %enddef
+#else
+	%define INSTANTIATE_DATA( f_name )
+	%feature("autodoc","1") _ ## f_name;
+	%template(f_name) _ ## f_name<double>;
+	%enddef
+#endif
+
+// linalg
+INSTANTIATE_DATA(sort)
+INSTANTIATE_DATA(mult)
+INSTANTIATE_DATA(AAt)
+INSTANTIATE_DATA(XAt)
+INSTANTIATE_DATA(applyBayerPattern)
+INSTANTIATE_DATA(conjugateGradient)
+INSTANTIATE_DATA(invSym)
+INSTANTIATE_DATA(normalize)
+
+/**** decomp ****/
+enum constraint_type { L1COEFFS, L2ERROR, PENALTY, SPARSITY, L2ERROR2, PENALTY2, FISTAMODE};
+
+INSTANTIATE_DATA(sparseProject)
+INSTANTIATE_DATA(lassoD)
+INSTANTIATE_DATA(lassoQq)
+INSTANTIATE_DATA(lassoMask)
+INSTANTIATE_DATA(lassoWeighted)
+INSTANTIATE_DATA(omp)
+INSTANTIATE_DATA(ompMask)
+INSTANTIATE_DATA(somp)
+INSTANTIATE_DATA(cd)
+INSTANTIATE_DATA(l1L2BCD)
+
+/**** dictLearn ****/
+enum constraint_type_D { L2,  L1L2, L1L2FL, L1L2MU};
+INSTANTIATE_DATA(alltrainDL)
+/* from arch */
+INSTANTIATE_DATA(archetypalAnalysis)
+INSTANTIATE_DATA(archetypalAnalysisInit)
+INSTANTIATE_DATA(decompSimplex)
+
+
+/**** prox ****/
+INSTANTIATE_DATA(fistaFlat)
+INSTANTIATE_DATA(fistaTree)
+INSTANTIATE_DATA(fistaGraph)
+INSTANTIATE_DATA(proximalFlat)
+INSTANTIATE_DATA(proximalTree)
+INSTANTIATE_DATA(proximalGraph)
+
+/* groups-graph */
+INSTANTIATE_DATA(simpleGroupTree)
+INSTANTIATE_DATA(readGroupStruct)
+INSTANTIATE_DATA(groupStructOfString)
+INSTANTIATE_DATA(graphOfGroupStruct)
+INSTANTIATE_DATA(treeOfGroupStruct)
+
+
+/* misc */
+INSTANTIATE_DATA(im2col_sliding)

--- a/tools/spams.i~
+++ b/tools/spams.i~
@@ -1,0 +1,221 @@
+%define DOCSTRING
+"This module gives access to some functions of the spams C++ library.
+The functions defined here should not be called directly.
+Use of spams functions should only be done through module spams."
+%enddef
+
+#ifdef SWIGPYTHON
+%module(docstring=DOCSTRING) spams_wrap
+#endif
+#ifdef SWIGR
+%module spams
+#endif
+
+%{
+#define SWIG_FILE_WITH_INIT
+
+#include "spams.h"
+#include "spams/prox/groups-graph.h"
+
+#ifdef DEBUG
+#include "spams-tst.h"
+#endif
+%}
+
+%define argout_vectors(ctype)
+	Vector<ctype> **omiter,
+	Vector<ctype> **peta_g,
+	Vector<ctype> **pown_variables,
+	Vector<ctype> **pN_own_variables
+%enddef
+
+/*
+   Following macros define which typemap must be applied to arguments of C++ functions are converted.
+   args of type inplace_* may containt input data or are ready (allocated)
+    to receive output data. Typemaps of type 'in' are applied to them
+    before function call. 
+   args of type argout_* are used when multiple return values are needed.
+    they are of type **; their storage is allocated on return of the C++ function.
+     Typemaps of type 'in' are applied to them  before function call,
+     and typemaps of type 'argout' are applied to them afeter the call.
+  Note : typemaps of type ('out') are applied to return values of C++ functions.
+*****
+
+*/
+// list of arguments of type INPLACE_MATRIX
+%define inplace_bool_matrices
+	Matrix<bool> *B
+%enddef
+%define inplace_bool_spmatrices
+    SpMatrix<bool> *groups,
+    SpMatrix<bool> *groups_var
+%enddef
+
+%define inplace_matrices(ctype)
+     Matrix<ctype> *A,
+     Matrix<ctype> *B,
+     Matrix<ctype> *D,
+     Matrix<ctype> *D1,
+     Matrix<ctype> *Q,
+     Matrix<ctype> *q,
+     Matrix<ctype> *U,
+     Matrix<ctype> *V,
+     Matrix<ctype> *X,
+     Matrix<ctype> *m_A,
+     Matrix<ctype> *m_B,
+     Matrix<ctype> *XAt,
+     Matrix<ctype> *Y,
+     Matrix<ctype> *XY,
+     Matrix<ctype> *AAt,
+     Matrix<ctype> *alpha0,
+     Matrix<ctype> *alpha,
+     Matrix<ctype> *W,
+     Matrix<ctype> *Z0,
+     Matrix<ctype> *Z
+%enddef
+%define argout_matrices(ctype)
+     Matrix<ctype> **path,
+     Matrix<ctype> **omA,
+     Matrix<ctype> **omB
+%enddef
+%define inplace_vectors(ctype)
+    Vector<ctype> *v,
+    Vector<ctype> *b,
+    Vector<ctype> *x,
+    Vector<ctype> *xCurr,
+    Vector<ctype> *inner_weights,
+    Vector<ctype> *L,
+    Vector<ctype> *eps,
+    Vector<ctype> *Lambda,
+    Vector<ctype> *eta_g,
+    Vector<ctype> *own_variables,
+    Vector<ctype> *N_own_variables,
+    Vector<ctype> *groups
+%enddef
+%define inplace_spmatrices(ctype)
+    SpMatrix<ctype> *A,
+    SpMatrix<ctype> *alpha,
+    SpMatrix<ctype> *groups
+%enddef
+%define argout_spmatrices(ctype)
+    SpMatrix<ctype> **pgroups,
+    SpMatrix<ctype> **pgroups_var,
+    SpMatrix<ctype> **spA,
+    SpMatrix<ctype> **spB
+%enddef
+
+%define inplace_dspmatrices(ctype)
+    AbstractMatrixB<ctype> *D
+%enddef
+
+%define inplace_datamatrices(ctype)
+    Data<ctype> *X
+%enddef
+
+%define inplace_nodes(ctype)
+	std::vector<StructNodeElem<ctype> *> *gstruct
+%enddef
+
+#ifdef SWIGPYTHON
+%include "typemaps.i"
+%init %{
+    import_array();
+%}
+#endif
+
+#ifdef SWIGR
+%include "R_typemaps.i"
+#endif
+%include "spamstools.i"
+%include "exception.i"
+
+
+%include <spams.h>
+%include <spams/prox/groups-graph.h>
+
+//void im2col_sliding(Matrix<double>  *,Matrix<double>  *,int,int,bool);
+//std::vector<NodeElem *> *simpleGroupTree(int *degr, int n)throw(const char *);
+//std::vector<NodeElem *> *readGroupStruct(const char* file) throw(const char *);
+//std::vector<NodeElem *> *groupStructOfString(const char* data) throw(const char *);
+//Vector<double> * graphOfGroupStruct(std::vector<NodeElem *> *tree,SpMatrix<bool> **pgroups,SpMatrix<bool> **pgroups_var) throw(const char *);
+
+//int  treeOfGroupStruct(std::vector<StructNodeElem<double> *> *tree,int **pperm,int *pnb_vars,Vector<double> **peta_g,SpMatrix<bool> **pgroups,Vector<int> **pown_variables,Vector<int> **pN_own_variables) throw(const char *);
+
+#ifdef DEBUG
+%include <spams-tst.h>
+Matrix<double> *tst(Matrix<double> **,bool,AbstractMatrixB<double> *);
+//int xtst(Matrix<double> **,bool );
+SpMatrix<double> *xtst(Matrix<double> **,bool );
+Matrix<double> *ztst(Data<double> *,Matrix<double> **omA,Matrix<double> **,Vector<int> **,bool) throw(const char *);
+
+#endif
+
+// In case of multiple instantiation :
+// template with same name : OK in spite of warning
+// But the args are checked to choose between implementations
+// special type need a typecheck typemap
+#ifndef WINDOWS
+       %define INSTANTIATE_DATA( f_name )
+       %feature("autodoc","1") _ ## f_name;
+       %template(f_name) _ ## f_name<double>;
+       %template(f_name) _ ## f_name<float>;
+       %enddef
+#else
+	%define INSTANTIATE_DATA( f_name )
+	%feature("autodoc","1") _ ## f_name;
+	%template(f_name) _ ## f_name<double>;
+	%enddef
+#endif
+
+// linalg
+INSTANTIATE_DATA(sort)
+INSTANTIATE_DATA(mult)
+INSTANTIATE_DATA(AAt)
+INSTANTIATE_DATA(XAt)
+INSTANTIATE_DATA(applyBayerPattern)
+INSTANTIATE_DATA(conjugateGradient)
+INSTANTIATE_DATA(invSym)
+INSTANTIATE_DATA(normalize)
+
+/**** decomp ****/
+enum constraint_type { L1COEFFS, L2ERROR, PENALTY, SPARSITY, L2ERROR2, PENALTY2, FISTAMODE};
+
+INSTANTIATE_DATA(sparseProject)
+INSTANTIATE_DATA(lassoD)
+INSTANTIATE_DATA(lassoQq)
+INSTANTIATE_DATA(lassoMask)
+INSTANTIATE_DATA(lassoWeighted)
+INSTANTIATE_DATA(omp)
+INSTANTIATE_DATA(ompMask)
+INSTANTIATE_DATA(somp)
+INSTANTIATE_DATA(cd)
+INSTANTIATE_DATA(l1L2BCD)
+
+/**** dictLearn ****/
+enum constraint_type_D { L2,  L1L2, L1L2FL, L1L2MU};
+INSTANTIATE_DATA(alltrainDL)
+/* from arch */
+INSTANTIATE_DATA(archetypalAnalysis)
+INSTANTIATE_DATA(archetypalAnalysisInit)
+INSTANTIATE_DATA(decompSimplex)
+
+
+/**** prox ****/
+INSTANTIATE_DATA(fistaFlat)
+INSTANTIATE_DATA(fistaTree)
+INSTANTIATE_DATA(fistaGraph)
+INSTANTIATE_DATA(proximalFlat)
+INSTANTIATE_DATA(proximalTree)
+INSTANTIATE_DATA(proximalGraph)
+
+/* groups-graph */
+INSTANTIATE_DATA(simpleGroupTree)
+INSTANTIATE_DATA(readGroupStruct)
+INSTANTIATE_DATA(groupStructOfString)
+INSTANTIATE_DATA(graphOfGroupStruct)
+INSTANTIATE_DATA(treeOfGroupStruct)
+
+
+/* misc */
+INSTANTIATE_DATA(im2col_sliding)
+

--- a/tools/spamstools.i
+++ b/tools/spamstools.i
@@ -1,0 +1,101 @@
+
+
+/* ***************************
+   macros to apply typemaps
+************************** */
+
+
+%define APPLY_INPLACE_VECTOR( ctype )
+%apply Vector<ctype> *INPLACE_VECTOR {
+       inplace_vectors(ctype)
+};
+%enddef
+%define APPLY_ARGOUT_VECTOR( ctype )
+%apply Vector<ctype> **ARGOUT_VECTOR {
+       argout_vectors(ctype)
+};
+%enddef
+
+
+%define APPLY_INPLACE_MATRIX( ctype )
+%apply Matrix<ctype> *INPLACE_MATRIX {
+       inplace_matrices(ctype)
+};
+%enddef
+%define APPLY_ARGOUT_MATRIX( ctype )
+%apply Matrix<ctype> **ARGOUT_MATRIX {
+       argout_matrices(ctype)
+};
+%enddef
+
+%define APPLY_INPLACE_SPMATRIX( ctype )
+%apply SpMatrix<ctype> *INPLACE_SPMATRIX {
+       inplace_spmatrices(ctype)
+};
+%enddef
+%define APPLY_ARGOUT_SPMATRIX( ctype )
+%apply SpMatrix<ctype> **ARGOUT_SPMATRIX {
+       argout_spmatrices(ctype)
+};
+%enddef
+
+%define APPLY_INPLACE_DSPMATRIX( ctype )
+%apply AbstractMatrixB<ctype> *INPLACE_DSPMATRIX {
+       inplace_dspmatrices(ctype)
+};
+%enddef
+%define APPLY_INPLACE_DATAMATRIX( ctype )
+%apply Data<ctype> *INPLACE_DATAMATRIX {
+       inplace_datamatrices(ctype)
+};
+%enddef
+
+%define APPLY_TREE( ctype )
+%apply std::vector<StructNodeElem<ctype> *> *TREE {
+       inplace_nodes(ctype)
+};
+%enddef
+
+APPLY_INPLACE_VECTOR(float)
+APPLY_INPLACE_VECTOR(double)
+APPLY_INPLACE_VECTOR(int)
+APPLY_ARGOUT_VECTOR(int)
+APPLY_ARGOUT_VECTOR(double)
+
+%apply Matrix<bool> *INPLACE_MATRIX {
+       inplace_bool_matrices
+};
+APPLY_INPLACE_MATRIX(float)
+APPLY_INPLACE_MATRIX(double)
+APPLY_INPLACE_MATRIX(bool)
+APPLY_ARGOUT_MATRIX(double)
+APPLY_ARGOUT_MATRIX(float)
+
+%apply SpMatrix<bool> *INPLACE_SPMATRIX {
+       inplace_bool_spmatrices
+};
+APPLY_INPLACE_SPMATRIX(float)
+APPLY_INPLACE_SPMATRIX(double)
+APPLY_INPLACE_SPMATRIX(bool)
+APPLY_ARGOUT_SPMATRIX(bool)
+APPLY_ARGOUT_SPMATRIX(double)
+APPLY_ARGOUT_SPMATRIX(float)
+
+APPLY_INPLACE_DSPMATRIX(float)
+APPLY_INPLACE_DSPMATRIX(double)
+
+APPLY_INPLACE_DATAMATRIX(double)
+APPLY_INPLACE_DATAMATRIX(float)
+
+APPLY_TREE(double)
+APPLY_TREE(float)
+
+#ifdef SWIGPYTHON
+%apply (int* INPLACE_ARRAY1,int DIM1) {
+       (int *degr, int n)
+};
+#endif
+%apply (int** ARGOUTVIEW_ARRAY1,int* DIM1) {
+       (int **pperm, int *pnb_vars)
+};
+


### PR DESCRIPTION
The swig files for generating the code again. I also added a new function on the python side to check for an int array explicitly, the old version had a problem doing type checking on windows x64 after python 3.8 because C int are 32bit for sparse matrix and decided to become 64bit afterwards, making the whole thing error out without reasons. 

See https://github.com/getspams/spams-python/compare/buildtools?expand=1#diff-460b6ecbea1ce33a85130c32946fe89e220bc7660355bfb71856fe1ecb6e5b05R13 for more info, copied and adapted from the line just below to do the bare minimum.

Note the updated wrappers are coming later and these files do not do anything by themselves for users.